### PR TITLE
[FEAT] 회원가입 완료 페이지 생성 및 로그인 구조 디자인 구현 마무리

### DIFF
--- a/src/components/Header/LoginHeader/LoginHeader.module.css
+++ b/src/components/Header/LoginHeader/LoginHeader.module.css
@@ -3,5 +3,10 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    flex-direction: column; /* 텍스트를 로고 아래로 */
+    flex-direction: column;
+}
+
+.login_logo{
+    width: fit-content;
+    height: fit-content;
 }

--- a/src/components/Header/MainHeader/Header.module.css
+++ b/src/components/Header/MainHeader/Header.module.css
@@ -31,8 +31,8 @@
 }
 
 .header_search_input {
-    width: 80%;
-    height: 4vh;
+    width: 90%;
+    height: 5vh;
 
     padding-left: 2%;
 

--- a/src/pages/InitialProfile/LoginComplete.js
+++ b/src/pages/InitialProfile/LoginComplete.js
@@ -10,12 +10,12 @@ const LoginComplete = () => {
     }
     return(
         <div className={styles.container}>
-            <LoginHeader style={{marginBottom:'-50px'}}/>
+            <LoginHeader/>
             <div className={styles.text}>
                 <p className={styles.subtitle}>
                     가입이 완료되었어요!
                 <br/>
-                    xx와 함께 즐거운 여행 되세요!
+                    PlayUs와 함께 즐거운 여행 되세요!
                 </p>
                 <button className={styles.button} onClick={navigateHome}>
                     시작하기

--- a/src/pages/InitialProfile/LoginComplete.js
+++ b/src/pages/InitialProfile/LoginComplete.js
@@ -1,0 +1,27 @@
+import styles from "./LoginComplete.module.css";
+import LoginHeader from "../../components/Header/LoginHeader/LoginHeader";
+import React from "react";
+import {useNavigate} from "react-router-dom";
+
+const LoginComplete = () => {
+    const navigate = useNavigate();
+    const navigateHome = (e) => {
+        navigate("/home");
+    }
+    return(
+        <div className={styles.container}>
+            <LoginHeader style={{marginBottom:'-50px'}}/>
+            <div className={styles.text}>
+                <p className={styles.subtitle}>
+                    가입이 완료되었어요!
+                <br/>
+                    xx와 함께 즐거운 여행 되세요!
+                </p>
+                <button className={styles.button} onClick={navigateHome}>
+                    시작하기
+                </button>
+            </div>
+        </div>
+    )
+}
+export default LoginComplete;

--- a/src/pages/InitialProfile/LoginComplete.module.css
+++ b/src/pages/InitialProfile/LoginComplete.module.css
@@ -1,0 +1,35 @@
+.container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 40px 20px;
+    font-family: 'Noto Sans KR', sans-serif;
+}
+
+.logo {
+    width: 140px;
+    margin-bottom: 20px;
+}
+
+.text{
+    text-Align: center;
+    margin-Top: 50px;
+}
+
+.subtitle{
+    font-Size: 20px;
+    font-Weight: bold;
+    margin-Bottom: 50px;
+}
+
+.button{
+    background-color: #FF5A5F;
+    color: white;
+    padding: 15px 40px;
+    border: none;
+    border-Radius: 20px;
+    font-Size: 16px;
+    cursor: pointer;
+    width: 207px;
+    height: 56px;
+}

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -1,8 +1,21 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styles from './Login.module.css';
 import LoginHeader from "../../components/Header/LoginHeader/LoginHeader";
+import Modal from "../../components/Modal/Modal";
+import {useNavigate} from "react-router-dom";
 
 function Login() {
+    const [showModal, setShowModal] = useState(false);
+    const navigate = useNavigate();
+    // 차후 회원 DB 적용시 모달 구현 예정
+    // const onButtonClick = () => {
+    //     if (!selectedTeam) {
+    //         setShowModal(true);
+    //         return;
+    //     }
+    //     navigate("/choice-team");
+    // }
+
     const handleKakaoLogin = () => {
         console.log('카카오로 시작하기 클릭됨');
     };
@@ -22,6 +35,7 @@ function Login() {
 
                 {/* 링크 나중에 수정 */}
                 <a href="/choice-team" className={`${styles.login_button} ${styles.kakao_button}`}>
+                {/*<a href="/choice-team" className={`${styles.login_button} ${styles.kakao_button}`} onClick={onButtonClick}>*/}
                     <img
                         src={`${process.env.PUBLIC_URL}/Logo/KaKao_logo.png`}
                         alt="Kakao Icon"
@@ -39,6 +53,13 @@ function Login() {
                     <span>네이버로 시작하기</span>
                 </a>
             </div>
+            {showModal && (
+                <Modal
+                    title="제재 안내"
+                    message="xxx 회원님께서는 타 사용자에게 ‘불쾌감을 주는 언행’으로 2025년 10월 4일까지 해당 서비스를 이용하실 수 없습니다."
+                    onClose={() => setShowModal(false)}
+                />
+            )}
 
         </div>
     );

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -53,13 +53,13 @@ function Login() {
                     <span>네이버로 시작하기</span>
                 </a>
             </div>
-            {showModal && (
-                <Modal
-                    title="제재 안내"
-                    message="xxx 회원님께서는 타 사용자에게 ‘불쾌감을 주는 언행’으로 2025년 10월 4일까지 해당 서비스를 이용하실 수 없습니다."
-                    onClose={() => setShowModal(false)}
-                />
-            )}
+            {/*{showModal && (*/}
+            {/*    <Modal*/}
+            {/*        title="제재 안내"*/}
+            {/*        message={`${userName} 회원님께서는 타 사용자에게 '불쾌감을 주는 언행'으로 ${endDate}까지 해당 서비스를 이용하실 수 없습니다.`}*/}
+            {/*        onClose={() => setShowModal(false)}*/}
+            {/*    />*/}
+            {/*)}*/}
 
         </div>
     );

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -10,6 +10,7 @@ import Party from '../components/Party';
 import Profile from '../components/Profile';
 import TeamChoice from "../pages/InitialProfile/TeamChoice";
 import SetProfile from "../pages/InitialProfile/SetProfile";
+import LoginComplete from "../pages/InitialProfile/LoginComplete";
 
 function AppRouter() {
     return (
@@ -19,6 +20,7 @@ function AppRouter() {
                 <Route path="/login" element={<Login />}/>
                 <Route path="/choice-team" element={<TeamChoice/>}/>
                 <Route path="/setprofile" element={<SetProfile/>}/>
+                <Route path="/login-complete" element={<LoginComplete/>}/>
                 <Route path="/home" element={<MobileView />}>
                     <Route index element={<MainPage />} />
                 </Route>


### PR DESCRIPTION
1. 회원가입 페이지 /login-complete url에 구현 및 route
2. 검색창 디자인 수정
3. 회원 제재 시 모달 로그인페이지에 구현 후 임시 주석처리

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 스플래시 디자인
![splash](https://github.com/user-attachments/assets/d38ba50e-90f4-45a4-9250-7591b26693fb)

### 2. 최초 계정 연동 페이지
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/69d1d05b-c79e-4a44-a8f8-8891b99c0e8f" />

### 3. 팀 선택 페이지
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/0cf84e62-e8c6-486a-a588-eb11fdd320ea" />

### 4. 사용자 프로필 설정 페이지
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/10058835-ecc0-46bf-834d-b1dde9595b1d" />

### 5. 회원가입 완료 페이지
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/181e1498-5ed9-4482-906f-1b4916a82dd6" />

---

## 🔗 관련 이슈
- closes #17 
- closes #15 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 회원가입 완료 후 안내 메시지와 함께 시작하기 버튼이 있는 로그인 완료 페이지가 추가되었습니다.
  - 로그인 완료 페이지는 새로운 경로(`/login-complete`)에서 접근할 수 있습니다.

- **스타일**
  - 로그인 완료 페이지 전용 스타일이 추가되었습니다.
  - 헤더 검색 입력창의 너비와 높이가 소폭 확대되었습니다.
  - 로그인 헤더에 새로운 로고 스타일이 추가되고 CSS 문법 오류가 수정되었습니다.

- **버그 수정**
  - 로그인 페이지에서 특정 상황에 따라 안내 모달이 표시될 수 있도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->