### PR TITLE
Cs 219 chore/프론트 jira 이슈 생성 시 task 만들어지도록 변경

### DIFF
--- a/.github/ISSUE_TEMPLATE/feat-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/feat-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 직업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/fix-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/fix-issue-form.yml
@@ -15,8 +15,8 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/fix-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/fix-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/performance-issue-form.yml
@@ -15,8 +15,8 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/performance-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/performance-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
@@ -15,8 +15,8 @@ body:
   - type : input
     id : parentKey
     attributes:
-      label: '상위 작업 (Story, 초록색 책갈피) Ticket Number'
-      description: '상위 직업 (Story, 초록색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
+      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
+++ b/.github/ISSUE_TEMPLATE/refactor-issue-form.yml
@@ -16,7 +16,7 @@ body:
     id : parentKey
     attributes:
       label: '상위 작업 (Epic, 보라색 번개) Ticket Number'
-      description: '상위 직업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
+      description: '상위 작업 (Epic, 보라색 아이콘) 의 Ticket Number를 기입해주세요, 노션에서도 확인 가능'
       value: CS-00
     validations:
       required: true

--- a/.github/workflows/create-jira-chore-issue.yml
+++ b/.github/workflows/create-jira-chore-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-feat-issue.yml
+++ b/.github/workflows/create-jira-feat-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 스토리
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-fix-issue.yml
+++ b/.github/workflows/create-jira-fix-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-performance-issue.yml
+++ b/.github/workflows/create-jira-performance-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |

--- a/.github/workflows/create-jira-refactor-issue.yml
+++ b/.github/workflows/create-jira-refactor-issue.yml
@@ -48,7 +48,7 @@ jobs:
         uses: atlassian/gajira-create@v3
         with:
           project: CS # JIRA KEY
-          issuetype: 하위 작업 # Task, Subtask 아님!
+          issuetype: Task
           summary: "${{ github.event.issue.title }}"
           description: "${{ steps.md2jira.outputs.output-text }}"
           fields: |


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [x] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
기존 체계에서 task 만 만들어지도록 변경햇습니다~

---

## 🔗 관련 이슈
- closes #24 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
    - 여러 이슈 템플릿에서 상위 작업 유형을 "Story"에서 "Epic"으로, 아이콘을 초록색 책갈피에서 보라색 번개로 변경하였습니다.
    - 일부 입력란의 한국어 문구를 더 자연스럽게 다듬었습니다.
- **Chores**
    - Jira 이슈 생성 워크플로우에서 이슈 타입을 "스토리" 또는 "하위 작업"에서 "Task"로 변경하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->