### PR TITLE
Cs 271 feat/사용자 닉네임 수정 구현

### DIFF
--- a/src/components/Form/PartyFormStep1.js
+++ b/src/components/Form/PartyFormStep1.js
@@ -17,13 +17,13 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
 
     const isFormValid = () => {
         return (
-            form.partyName &&
-            form.applyType &&
-            form.gender &&
-            form.age &&
-            form.min &&
-            form.max &&
-            form.min < form.max
+            form.title &&
+            form.partyJoinMethod &&
+            form.partyGender &&
+            form.ageGroup &&
+            form.minimumParticipants &&
+            form.maximumParticipants &&
+            form.minimumParticipants < form.maximumParticipants
         );
     };
 
@@ -43,8 +43,8 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                 <h2 className={styles.title}>파티 이름을 설정해 주세요.</h2>
                 <input
                     type="text"
-                    value={form.partyName || ''}
-                    onChange={e => handleChange('partyName', e.target.value)}
+                    value={form.title || ''}
+                    onChange={e => handleChange('title', e.target.value)}
                     placeholder="부적절한 명칭 설정은 제재를 받을 수 있습니다."
                     className={styles.input}
                 />
@@ -54,8 +54,8 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                     {['선착순', '승인제'].map(type => (
                         <button
                             key={type}
-                            className={`${styles.button} ${form.applyType === type ? styles.buttonActive : ''}`}
-                            onClick={() => handleChange('applyType', type)}
+                            className={`${styles.button} ${form.partyJoinMethod === type ? styles.buttonActive : ''}`}
+                            onClick={() => handleChange('partyJoinMethod', type)}
                         >
                             {type}
                         </button>
@@ -67,8 +67,8 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                     {['남자만', '여자만', '상관없음'].map(gender => (
                         <button
                             key={gender}
-                            className={`${styles.button} ${form.gender === gender ? styles.buttonActive : ''}`}
-                            onClick={() => handleChange('gender', gender)}
+                            className={`${styles.button} ${form.partyGender === gender ? styles.buttonActive : ''}`}
+                            onClick={() => handleChange('partyGender', gender)}
                         >
                             {gender}
                         </button>
@@ -80,8 +80,8 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                     {['10대', '20대', '30대', '40대', '50대', '60대 이상'].map(age => (
                         <button
                             key={age}
-                            className={`${styles.button} ${form.age === age ? styles.buttonActive : ''}`}
-                            onClick={() => handleChange('age', age)}
+                            className={`${styles.button} ${form.ageGroup === age ? styles.buttonActive : ''}`}
+                            onClick={() => handleChange('ageGroup', age)}
                         >
                             {age}
                         </button>
@@ -97,11 +97,11 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                             min={1}
                             max={20}
                             step={1}
-                            value={form.min || ''}
+                            value={form.minimumParticipants || ''}
                             onChange={e => {
                                 const value = Math.floor(Number(e.target.value));
                                 if (value > 0) {
-                                    handleChange('min', value);
+                                    handleChange('minimumParticipants', value);
                                 }
                             }}
                             className={styles.numberInput}
@@ -112,14 +112,14 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                         최대
                         <input
                             type="number"
-                            min={form.min || 1}
+                            min={form.minimumParticipants || 1}
                             max={20}
                             step={1}
-                            value={form.max || ''}
+                            value={form.maximumParticipants || ''}
                             onChange={e => {
                                 const value = Math.floor(Number(e.target.value));
-                                if (value > 0 && value >= (form.min || 1)) {
-                                    handleChange('max', value);
+                                if (value > 0 && value >= (form.minimumParticipants || 1)) {
+                                    handleChange('maximumParticipants', value);
                                 }
                             }}
                             className={styles.numberInput}
@@ -132,17 +132,17 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
             <button
                 onClick={() => {
                     if (!isFormValid()) {
-                        if (!form.partyName) {
+                        if (!form.title) {
                             setModalMessage('파티 이름을 입력해 주세요.');
-                        } else if (!form.applyType) {
+                        } else if (!form.partyJoinMethod) {
                             setModalMessage('신청 방식을 선택해 주세요.');
-                        } else if (!form.gender) {
+                        } else if (!form.partyGender) {
                             setModalMessage('참여 성별을 선택해 주세요.');
-                        } else if (!form.age) {
+                        } else if (!form.ageGroup) {
                             setModalMessage('참여자의 나이를 설정해 주세요.');
-                        } else if (!form.min || !form.max) {
+                        } else if (!form.minimumParticipants || !form.maximumParticipants) {
                             setModalMessage('최소 및 최대 인원을 입력해 주세요.');
-                        } else if (form.min >= form.max) {
+                        } else if (form.minimumParticipants >= form.maximumParticipants) {
                             setModalMessage('최소 인원은 최대 인원보다 클 수 없습니다.');
                         }
                         setModalOpen(true);

--- a/src/components/Form/PartyFormStep2.js
+++ b/src/components/Form/PartyFormStep2.js
@@ -59,7 +59,7 @@ const PartyFormStep2 = ({form, setForm, onSubmit}) => {
     const tabLabels = ["직관팟 만들기"];
 
     const isFormValid = () => {
-        if (!form.description || form.description.trim() === '') {
+        if (!form.message || form.message.trim() === '') {
             alert('소개글을 작성해 주세요.');
             return false;
         }
@@ -114,14 +114,14 @@ const PartyFormStep2 = ({form, setForm, onSubmit}) => {
                 <h2 className={styles.title}>소개글을 작성해 주세요.</h2>
                 <textarea
                     rows="8"
-                    value={form.description || ''}
-                    onChange={(e) => handleChange('description', e.target.value)}
+                    value={form.message || ''}
+                    onChange={(e) => handleChange('message', e.target.value)}
                     placeholder="소개글을 자유롭게 작성해 주세요. (최대 500자)"
                     maxLength={500}
                     className={styles.textarea}
                 />
                 <div className={styles.charCount}>
-                    {form.description?.length || 0}/500
+                    {form.message?.length || 0}/500
                 </div>
 
                 <button

--- a/src/components/Header/MainHeader/Header.js
+++ b/src/components/Header/MainHeader/Header.js
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { useState } from "react";
+import NotificationModal from "../../Modal/NotificationModal/NotificationModal";
 import {useNavigate} from "react-router-dom";
 import styles from "./Header.module.css";
 import {useSearch} from "../../SearchContext";
@@ -6,6 +7,8 @@ import {useSearch} from "../../SearchContext";
 const Header = () => {
     const {inputValue, setInputValue, setKeyword} = useSearch();
     const navigate = useNavigate();
+
+    const [showModal, setShowModal] = useState(false);
 
     const handleKeyDown = (e) => {
         if (e.key === "Enter" && inputValue.trim() !== "") {
@@ -38,21 +41,23 @@ const Header = () => {
                     onKeyDown={handleKeyDown}
                 />
             </div>
-            <div className={styles.header_right}>
+            <div className={`${styles.header_right} ${styles.header_right_absolute}`}>
                 <button>
+                    {/* 관리자 기능은 현재 Non-MVP이므로 미구현 */}
                     <img
                         src={`${process.env.PUBLIC_URL}/Button/admin.png`}
-                        alt="알림"
+                        alt="관리자"
                         className={styles.noti_alert}
                     />
                 </button>
-                <button>
+                <button onClick={() => setShowModal(!showModal)}>
                     <img
                         src={`${process.env.PUBLIC_URL}/Button/alert.png`}
                         alt="알림"
                         className={styles.noti_alert}
                     />
                 </button>
+                {showModal && <NotificationModal onClose={() => setShowModal(false)} />}
             </div>
         </header>
     );

--- a/src/components/Header/MainHeader/Header.module.css
+++ b/src/components/Header/MainHeader/Header.module.css
@@ -48,10 +48,11 @@
 .header_right {
     display: flex;
     align-items: center;
+    position: relative;
 }
 
 .header_right button {
-    background: none;
+    /*background: none;*/
     border: none;
     cursor: pointer;
     margin-left: 1%;

--- a/src/components/Modal/NotificationModal/NotificationModal.js
+++ b/src/components/Modal/NotificationModal/NotificationModal.js
@@ -1,0 +1,129 @@
+import React, {useState} from "react";
+import styles from "./NotificationModal.module.css";
+
+const tabs = ["전체", "직관팟", "커뮤니티"];
+
+const dummyData = {
+    전체: [
+        {
+            id: 1,
+            category: "직관팟",
+            type: "참가요청",
+            user: "Ashwin Bose",
+            date: "3/22(토)",
+            message: "한화 vs KT 개막전 직관 파티 참가를 요청했어요.",
+            content: "“안녕하세요! 저도 이 경기 같이 직관하고 싶어요!”",
+            new: true,
+            status: null
+        },
+        {
+            id: 2,
+            category: "직관팟",
+            type: "승인",
+            user: "ZSJ",
+            date: "3/27(토)",
+            message: "한화 vs 삼성 직관 함께보기 가 승인되었어요!",
+            content: "가입이 승인되었어요!",
+            new: false
+        },
+    ],
+    직관팟: [
+        {
+            id: 1,
+            category: "직관팟",
+            type: "참가요청",
+            user: "Ashwin Bose",
+            date: "3/22(토)",
+            message: "한화 vs KT 개막전 직관 파티 참가 요청",
+            content: "“안녕하세요! 저도 이 경기 같이 직관하고 싶어요!”",
+            new: true,
+            status: null
+        },
+        {
+            id: 2,
+            category: "직관팟",
+            type: "승인",
+            user: "ZSJ",
+            date: "3/27(토)",
+            message: "한화 vs 삼성 직관 함께보기 승인",
+            content: "가입이 승인되었어요!",
+            new: false
+        },
+    ],
+    커뮤니티: [],
+};
+
+const NotificationModal = ({onClose}) => {
+    const [activeTab, setActiveTab] = useState("전체");
+    const [notifications, setNotifications] = useState(dummyData);
+
+    const filtered = notifications[activeTab];
+
+    const handleClearAll = () => {
+        const cleared = {};
+        for (const key in notifications) {
+            cleared[key] = notifications[key].filter(
+                (item) => item.type === "참가요청" && item.status === null
+            );
+        }
+        setNotifications(cleared);
+    };
+
+    const handleRespond = (id, decision) => {
+        const updated = {};
+        for (const key in notifications) {
+            updated[key] = notifications[key].map((n) =>
+                n.id === id ? { ...n, status: decision } : n
+            );
+        }
+        setNotifications(updated);
+    };
+
+    return (
+        <div className={styles.modalWrapper}>
+            <div className={styles.modal}>
+                <div className={styles.header}>
+                    <h3>전체 알림</h3>
+                    <button onClick={handleClearAll}>전체 알림 삭제하기</button>
+                </div>
+                <div className={styles.tabs}>
+                    {tabs.map((tab) => (
+                        <button
+                            key={tab}
+                            className={activeTab === tab ? styles.active : ""}
+                            onClick={() => setActiveTab(tab)}
+                        >
+                            {tab}
+                        </button>
+                    ))}
+                </div>
+                <div className={styles.notifications}>
+                    {filtered.length === 0 ? (
+                        <div className={styles.empty}>알림이 없습니다.</div>
+                    ) : (
+                        filtered.map((item) => (
+                            <div key={item.id} className={`${styles.notificationItem} ${item.new ? styles.newAlert : ""}`}>
+                                {item.new && <span className={styles.newDot}/>}
+                                <div className={styles.notificationText}>
+                                    <strong>{item.user}</strong>님이 {item.date} {item.message}
+                                    <div className={styles.subText}>{item.content}</div>
+                                    {item.type === "참가요청" && item.status == null && (
+                                      <div className={styles.actionButtons}>
+                                        <button className={styles.approve} onClick={() => handleRespond(item.id, "승인")}>승인하기</button>
+                                        <button className={styles.reject} onClick={() => handleRespond(item.id, "거부")}>거부하기</button>
+                                      </div>
+                                    )}
+                                    {item.type === "참가요청" && item.status !== null && (
+                                      <div className={styles.resultText}>{item.status}되었어요!</div>
+                                    )}
+                                </div>
+                            </div>
+                        ))
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default NotificationModal;

--- a/src/components/Modal/NotificationModal/NotificationModal.module.css
+++ b/src/components/Modal/NotificationModal/NotificationModal.module.css
@@ -1,0 +1,129 @@
+.modalWrapper {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    /*margin-top: 8px;*/
+    z-index: 999;
+}
+
+.modal {
+    /*width: 100%;*/
+    width: 19rem;
+    max-width: 360px;
+    background-color: #fff;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    border-radius: 12px;
+    overflow: hidden;
+    font-family: 'Arial', sans-serif;
+}
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    /*border-bottom: 1px solid #e0e0e0;*/
+    /*background-color: #f8f9fa;*/
+}
+
+.header h3 {
+    font-weight: bold;
+    margin-top: 3px;
+}
+
+.tabs {
+    display: flex;
+    border-bottom: 1px solid #ddd;
+}
+
+.tabs button {
+    flex: 1;
+    padding: 10px;
+    background: none;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.active {
+    font-weight: bold;
+    border-bottom: 2px solid #007bff;
+    color: #007bff;
+}
+
+.notifications {
+    max-height: 320px;
+    overflow-y: auto;
+}
+
+.notificationItem {
+    display: flex;
+    padding: 12px 16px;
+    border-bottom: 1px solid #eee;
+    position: relative;
+}
+
+.newAlert {
+    background-color: #EDF3FF;
+}
+
+.newDot {
+    width: 8px;
+    height: 8px;
+    background-color: #6f42c1;
+    border-radius: 50%;
+    position: absolute;
+    left: 10px;
+    top: 18px;
+}
+
+.notificationText {
+    padding-left: 16px;
+    font-size: 13px;
+}
+
+.subText {
+    margin-top: 4px;
+    color: #666;
+    font-size: 12px;
+}
+
+.empty {
+    text-align: center;
+    padding: 40px 0;
+    color: #aaa;
+}
+
+.actionButtons {
+    margin-top: 8px;
+    display: flex;
+    gap: 8px;
+}
+
+.approve {
+    background-color: #ff4d4f;
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 6px 16px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.reject {
+    background-color: #fff;
+    color: #333;
+    border: 1px solid #d9d9d9;
+    border-radius: 6px;
+    padding: 6px 16px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.resultText {
+    margin-top: 8px;
+    font-size: 13px;
+    color: #555;
+}

--- a/src/components/Modal/ProfileEditModal/ProfileEditModal.js
+++ b/src/components/Modal/ProfileEditModal/ProfileEditModal.js
@@ -1,13 +1,18 @@
 // 프로필 편집 모달 컴포넌트
 import React, {useEffect, useState} from 'react';
+import axios from 'axios';
 import styles from './ProfileEditModal.module.css';
 
-const ProfileEditModal = ({onClose, onSubmit}) => {
-    const [nickname, setNickname] = useState('ZSJ');
+const ProfileEditModal = ({ onClose, onSubmit, initialNickname }) => {
+    const [nickname, setNickname] = useState(initialNickname);
     const [validationMessage, setValidationMessage] = useState('사용할 수 있는 닉네임입니다.');
     const [isValid, setIsValid] = useState(true);
     const [profileImage, setProfileImage] = useState(`${process.env.PUBLIC_URL}/Logo/default.png`);
     const [objectUrl, setObjectUrl] = useState(null);
+
+    useEffect(() => {
+        setNickname(initialNickname);
+    }, [initialNickname]);
 
     useEffect(() => {
         // 컴포넌트 언마운트 시 객체 URL 해제
@@ -47,11 +52,25 @@ const ProfileEditModal = ({onClose, onSubmit}) => {
         }
     };
 
-    const handleSubmit = () => {
-        // if (validationMessage !== '사용할 수 있는 닉네임입니다.') return;
+    const handleSubmit = async () => {
         if (!isValid) return;
-        onSubmit(nickname);
-        onClose();
+
+        try {
+            const res = await axios.put(
+                `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/nickname`,
+                { nickname },
+                { withCredentials: true }
+            );
+
+            if (res.status === 200) {
+                onSubmit(nickname);
+                onClose();
+            }
+        } catch (error) {
+            console.error("닉네임 수정 오류:", error);
+            setValidationMessage('닉네임 수정 중 오류가 발생했습니다.');
+            setIsValid(false);
+        }
     };
 
     return (

--- a/src/components/Modal/ProfileEditModal/ProfileEditModal.js
+++ b/src/components/Modal/ProfileEditModal/ProfileEditModal.js
@@ -7,7 +7,7 @@ const ProfileEditModal = ({ onClose, onSubmit, initialNickname }) => {
     const [nickname, setNickname] = useState(initialNickname);
     const [validationMessage, setValidationMessage] = useState('사용할 수 있는 닉네임입니다.');
     const [isValid, setIsValid] = useState(true);
-    const [profileImage, setProfileImage] = useState(`${process.env.PUBLIC_URL}/Logo/default.png`);
+    const [profileImage, setProfileImage] = useState(`${process.env.PUBLIC_URL}/profile/user2.jpg`);
     const [objectUrl, setObjectUrl] = useState(null);
 
     useEffect(() => {

--- a/src/pages/Community/Community.js
+++ b/src/pages/Community/Community.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import PostListItem from '../../components/Post/PostListItem';
 import styles from './Community.module.css';
+import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import CasterbotModal from "../Chatbot/CasterbotModal";
 // import Modal from '../../components/Modal/Modal';
 
 const initialPosts = [
@@ -44,6 +46,8 @@ const Community = () => {
   const [posts, setPosts] = useState(initialPosts);
   const [showAbsModal, setShowAbsModal] = useState(false);
   const [profanityMessage, setProfanityMessage] = useState('');
+  const [showCasterbot, setShowCasterbot] = useState(false);
+
 
   useEffect(() => {
     // location.state.team이 있으면 해당 팀으로 세팅
@@ -221,7 +225,11 @@ const Community = () => {
           </div>
         </div>
       )}
-      
+      <CasterbotButton onClick={() => setShowCasterbot(true)} />
+
+      {showCasterbot && (
+          <CasterbotModal onClose={() => setShowCasterbot(false)}/>
+      )}
     </div>
   );
 };

--- a/src/pages/Community/PostDetail.js
+++ b/src/pages/Community/PostDetail.js
@@ -1,6 +1,8 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {useLocation, useNavigate, useParams} from 'react-router-dom';
 import styles from './PostDetail.module.css';
+import axios from 'axios';
+import Modal from '../../components/Modal/Modal';
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 
@@ -15,26 +17,48 @@ const samplePosts = [
 ];
 
 const PostDetail = () => {
-    const {postId} = useParams();
-    const navigate = useNavigate();
-    const location = useLocation();
-    const [showPostMenu, setShowPostMenu] = useState(false); // 게시글 삼점바
-    const [showCommentMenu, setShowCommentMenu] = useState(null); // 댓글 삼점바(댓글 id)
-    const [showReplyMenu, setShowReplyMenu] = useState(null); // 대댓글 삼점바(댓글id_대댓글id)
-    const [comment, setComment] = useState("");
-    const [comments, setComments] = useState([]);
-    const [replyTo, setReplyTo] = useState(null); // 대댓글 대상
-    const commentInputRef = useRef(null); // 입력창 참조
-    const [editingCommentId, setEditingCommentId] = useState(null);
-    const [editingContent, setEditingContent] = useState("");
-    const [isEditing, setIsEditing] = useState(false);
-    const [editedContent, setEditedContent] = useState('');
-    const [editedTitle, setEditedTitle] = useState('');
-    const [isCommentEditing, setIsCommentEditing] = useState(false);
-    const [editedComment, setEditedComment] = useState('');
-    const [currentUser, setCurrentUser] = useState(null); // 현재 로그인한 사용자
-    const [showMenu, setShowMenu] = useState(false);
+  const { postId } = useParams();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [showPostMenu, setShowPostMenu] = useState(false); // 게시글 삼점바
+  const [showCommentMenu, setShowCommentMenu] = useState(null); // 댓글 삼점바(댓글 id)
+  const [showReplyMenu, setShowReplyMenu] = useState(null); // 대댓글 삼점바(댓글id_대댓글id)
+  const [comment, setComment] = useState("");
+  const [comments, setComments] = useState([]);
+  const [replyTo, setReplyTo] = useState(null); // 대댓글 대상
+  const commentInputRef = useRef(null); // 입력창 참조
+  const [editingCommentId, setEditingCommentId] = useState(null);
+  const [editingContent, setEditingContent] = useState("");
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState('');
+  const [editedTitle, setEditedTitle] = useState('');
+  const [isCommentEditing, setIsCommentEditing] = useState(false);
+  const [editedComment, setEditedComment] = useState('');
+  const [currentUser, setCurrentUser] = useState(null); // 현재 로그인한 사용자
+  const [showMenu, setShowMenu] = useState(false);
     const [showCasterbot, setShowCasterbot] = useState(false);
+  const [showAbsModal, setShowAbsModal] = useState(false);
+  const [profanityMessage, setProfanityMessage] = useState('');
+
+  const checkProfanity = async (text) => {
+    try {
+      const response = await axios.post(
+        'https://xrnfbckpskycrstm.tunnel.elice.io/detect',
+        { sentence: text },
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+      const raw = response.data.result
+        .replace(/```json\n/, '')
+        .replace(/`{3,}[\s\S]*$/, '')
+        .trim();
+      const parsed = JSON.parse(raw);
+      const isCurse = String(parsed.is_curse).toLowerCase() === 'true';
+      return { isCurse, words: parsed.words || [] };
+    } catch (error) {
+      console.error('비속어 감지 실패:', error);
+      return { isCurse: false, words: [] };
+    }
+  };
 
     const teamLogoMap = {
         hanwha: 'HH',
@@ -106,11 +130,19 @@ const PostDetail = () => {
         }, 0);
     };
 
-    // 댓글/답글 등록
-    const handleAddComment = () => {
-        if (!comment.trim()) return;
-        const user = JSON.parse(localStorage.getItem('user'));
-        const author = user?.nickname || user?.name || '익명';
+  // 댓글/답글 등록
+  const handleAddComment = async () => {
+    if (!comment.trim()) return;
+
+    const { isCurse, words } = await checkProfanity(comment);
+    if (isCurse) {
+      setProfanityMessage(words.join(', '));
+      setShowAbsModal(true);
+      return;
+    }
+
+    const user = JSON.parse(localStorage.getItem('user'));
+    const author = user?.nickname || user?.name || '익명';
 
         if (replyTo) {
             // 답글 등록
@@ -382,6 +414,25 @@ const PostDetail = () => {
                     </button>
                 </div>
             </div>
+            {showAbsModal && (
+                <Modal
+                    title="ABS봇이 작동중입니다."
+                    message={
+                        <>
+                            ABS봇이 부적절한 키워드를 감지했습니다.
+                            <br />
+                            작성글을 수정해 주세요.
+                            <br />
+                            <br />
+                            감지된 단어: {profanityMessage}
+                        </>
+                    }
+                    buttons={[
+                        { label: '확인', onClick: () => setShowAbsModal(false) }
+                    ]}
+                    onClose={() => setShowAbsModal(false)}
+                />
+            )}
             <CasterbotButton onClick={() => setShowCasterbot(true)}/>
 
             {showCasterbot && (

--- a/src/pages/Community/PostDetail.js
+++ b/src/pages/Community/PostDetail.js
@@ -1,364 +1,394 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import React, {useEffect, useRef, useState} from 'react';
+import {useLocation, useNavigate, useParams} from 'react-router-dom';
 import styles from './PostDetail.module.css';
+import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import CasterbotModal from "../Chatbot/CasterbotModal";
 
 // 게시글 샘플 데이터 (실제로는 API에서 가져와야 함)
 const samplePosts = [
-  { id: 1, title: "비와서 경기 종료", time: "18:36", author: "이플립스", content: "오늘 야구 경기 정말 재미있었습니다." },
-  { id: 2, title: "좋은 야구", time: "18:20", author: "류현진", content: "좋은 경기였습니다." },
-  { id: 3, title: "이번 경기 대박", time: "18:12", author: "닭강정", content: "대박 경기였습니다." },
-  { id: 4, title: "비와서 경기 종료", time: "18:36", author: "오미나", content: "비가 와서 경기가 취소되었습니다." },
-  { id: 5, title: "시범경기 이대로 끝나면 3위", time: "18:32", author: "김철룡", content: "시범경기 결과입니다." },
-  { id: 6, title: "시범경기 이대로 끝나면 3위", time: "18:32", author: "김현호", content: "시범경기 결과입니다." },
+    {id: 1, title: "비와서 경기 종료", time: "18:36", author: "이플립스", content: "오늘 야구 경기 정말 재미있었습니다."},
+    {id: 2, title: "좋은 야구", time: "18:20", author: "류현진", content: "좋은 경기였습니다."},
+    {id: 3, title: "이번 경기 대박", time: "18:12", author: "닭강정", content: "대박 경기였습니다."},
+    {id: 4, title: "비와서 경기 종료", time: "18:36", author: "오미나", content: "비가 와서 경기가 취소되었습니다."},
+    {id: 5, title: "시범경기 이대로 끝나면 3위", time: "18:32", author: "김철룡", content: "시범경기 결과입니다."},
+    {id: 6, title: "시범경기 이대로 끝나면 3위", time: "18:32", author: "김현호", content: "시범경기 결과입니다."},
 ];
 
 const PostDetail = () => {
-  const { postId } = useParams();
-  const navigate = useNavigate();
-  const location = useLocation();
-  const [showPostMenu, setShowPostMenu] = useState(false); // 게시글 삼점바
-  const [showCommentMenu, setShowCommentMenu] = useState(null); // 댓글 삼점바(댓글 id)
-  const [showReplyMenu, setShowReplyMenu] = useState(null); // 대댓글 삼점바(댓글id_대댓글id)
-  const [comment, setComment] = useState("");
-  const [comments, setComments] = useState([]);
-  const [replyTo, setReplyTo] = useState(null); // 대댓글 대상
-  const commentInputRef = useRef(null); // 입력창 참조
-  const [editingCommentId, setEditingCommentId] = useState(null);
-  const [editingContent, setEditingContent] = useState("");
-  const [isEditing, setIsEditing] = useState(false);
-  const [editedContent, setEditedContent] = useState('');
-  const [editedTitle, setEditedTitle] = useState('');
-  const [isCommentEditing, setIsCommentEditing] = useState(false);
-  const [editedComment, setEditedComment] = useState('');
-  const [currentUser, setCurrentUser] = useState(null); // 현재 로그인한 사용자
-  const [showMenu, setShowMenu] = useState(false);
+    const {postId} = useParams();
+    const navigate = useNavigate();
+    const location = useLocation();
+    const [showPostMenu, setShowPostMenu] = useState(false); // 게시글 삼점바
+    const [showCommentMenu, setShowCommentMenu] = useState(null); // 댓글 삼점바(댓글 id)
+    const [showReplyMenu, setShowReplyMenu] = useState(null); // 대댓글 삼점바(댓글id_대댓글id)
+    const [comment, setComment] = useState("");
+    const [comments, setComments] = useState([]);
+    const [replyTo, setReplyTo] = useState(null); // 대댓글 대상
+    const commentInputRef = useRef(null); // 입력창 참조
+    const [editingCommentId, setEditingCommentId] = useState(null);
+    const [editingContent, setEditingContent] = useState("");
+    const [isEditing, setIsEditing] = useState(false);
+    const [editedContent, setEditedContent] = useState('');
+    const [editedTitle, setEditedTitle] = useState('');
+    const [isCommentEditing, setIsCommentEditing] = useState(false);
+    const [editedComment, setEditedComment] = useState('');
+    const [currentUser, setCurrentUser] = useState(null); // 현재 로그인한 사용자
+    const [showMenu, setShowMenu] = useState(false);
+    const [showCasterbot, setShowCasterbot] = useState(false);
 
-  const teamLogoMap = {
-    hanwha: 'HH',
-    lg: 'LG',
-    kt: 'KT',
-    ssg: 'SK',
-    nc: 'NC',
-    doosan: 'OB',
-    kia: 'HT',
-    samsung: 'SS',
-    lotte: 'LT',
-    kiwoom: 'WO'
-  };
+    const teamLogoMap = {
+        hanwha: 'HH',
+        lg: 'LG',
+        kt: 'KT',
+        ssg: 'SK',
+        nc: 'NC',
+        doosan: 'OB',
+        kia: 'HT',
+        samsung: 'SS',
+        lotte: 'LT',
+        kiwoom: 'WO'
+    };
 
-  // localStorage의 communityPosts에서만 찾기 (샘플 데이터 제외)
-  let saved = [];
-  try {
-    saved = JSON.parse(localStorage.getItem('communityPosts') ?? '[]');
-  } catch (error) {
-    console.error('게시물 데이터를 불러오는 중 오류가 발생했습니다:', error);
-    saved = [];
-  }
-  const post = saved.find(p => String(p.id) === String(postId));
-
-  // 댓글 불러오기
-  useEffect(() => {
-    let savedComments = [];
+    // localStorage의 communityPosts에서만 찾기 (샘플 데이터 제외)
+    let saved = [];
     try {
-      savedComments = JSON.parse(localStorage.getItem(`comments_${postId}`) ?? '[]');
+        saved = JSON.parse(localStorage.getItem('communityPosts') ?? '[]');
     } catch (error) {
-      console.error('댓글 데이터를 불러오는 중 오류가 발생했습니다:', error);
-      savedComments = [];
+        console.error('게시물 데이터를 불러오는 중 오류가 발생했습니다:', error);
+        saved = [];
     }
-    setComments(savedComments);
-  }, [postId]);
+    const post = saved.find(p => String(p.id) === String(postId));
 
-  useEffect(() => {
-    // localStorage에서 현재 로그인한 사용자 정보 가져오기
-    let user = null;
-    try {
-      const userData = localStorage.getItem('user') ?? 'null';
-      user = JSON.parse(userData);
-      if (user === null || typeof user !== 'object') {
-        user = null;
-      }
-    } catch (error) {
-      console.error('사용자 정보를 불러오는 중 오류가 발생했습니다:', error);
-      user = null;
-    }
-    setCurrentUser(user);
-  }, []);
-
-  // 댓글 저장
-  const saveComments = (newComments) => {
-    setComments(newComments);
-    try {
-      localStorage.setItem(`comments_${postId}`, JSON.stringify(newComments));
-    } catch (error) {
-      console.error('댓글 저장 중 오류가 발생했습니다:', error);
-    }
-  };
-
-  // 답글쓰기 버튼 클릭 시
-  const handleReplyClick = (commentId) => {
-    setReplyTo(commentId);
-    // 입력창에 포커스
-    setTimeout(() => {
-      commentInputRef.current?.focus();
-    }, 0);
-  };
-
-  // 댓글/답글 등록
-  const handleAddComment = () => {
-    if (!comment.trim()) return;
-    const user = JSON.parse(localStorage.getItem('user'));
-    const author = user?.nickname || user?.name || '익명';
-
-    if (replyTo) {
-      // 답글 등록
-      const newComments = comments.map(c => {
-        if (c.id === replyTo) {
-          return {
-            ...c,
-            replies: [...(c.replies || []), {
-              id: Date.now(),
-              content: comment,
-              author,
-              time: new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})
-            }]
-          };
+    // 댓글 불러오기
+    useEffect(() => {
+        let savedComments = [];
+        try {
+            savedComments = JSON.parse(localStorage.getItem(`comments_${postId}`) ?? '[]');
+        } catch (error) {
+            console.error('댓글 데이터를 불러오는 중 오류가 발생했습니다:', error);
+            savedComments = [];
         }
-        return c;
-      });
-      saveComments(newComments);
-      setReplyTo(null); // 답글 모드 해제
-    } else {
-      // 일반 댓글 등록
-      const newComment = {
-        id: Date.now(),
-        content: comment,
-        author,
-        time: new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'}),
-        replies: [],
-      };
-      const newComments = [...comments, newComment];
-      saveComments(newComments);
+        setComments(savedComments);
+    }, [postId]);
+
+    useEffect(() => {
+        // localStorage에서 현재 로그인한 사용자 정보 가져오기
+        let user = null;
+        try {
+            const userData = localStorage.getItem('user') ?? 'null';
+            user = JSON.parse(userData);
+            if (user === null || typeof user !== 'object') {
+                user = null;
+            }
+        } catch (error) {
+            console.error('사용자 정보를 불러오는 중 오류가 발생했습니다:', error);
+            user = null;
+        }
+        setCurrentUser(user);
+    }, []);
+
+    // 댓글 저장
+    const saveComments = (newComments) => {
+        setComments(newComments);
+        try {
+            localStorage.setItem(`comments_${postId}`, JSON.stringify(newComments));
+        } catch (error) {
+            console.error('댓글 저장 중 오류가 발생했습니다:', error);
+        }
+    };
+
+    // 답글쓰기 버튼 클릭 시
+    const handleReplyClick = (commentId) => {
+        setReplyTo(commentId);
+        // 입력창에 포커스
+        setTimeout(() => {
+            commentInputRef.current?.focus();
+        }, 0);
+    };
+
+    // 댓글/답글 등록
+    const handleAddComment = () => {
+        if (!comment.trim()) return;
+        const user = JSON.parse(localStorage.getItem('user'));
+        const author = user?.nickname || user?.name || '익명';
+
+        if (replyTo) {
+            // 답글 등록
+            const newComments = comments.map(c => {
+                if (c.id === replyTo) {
+                    return {
+                        ...c,
+                        replies: [...(c.replies || []), {
+                            id: Date.now(),
+                            content: comment,
+                            author,
+                            time: new Date().toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+                        }]
+                    };
+                }
+                return c;
+            });
+            saveComments(newComments);
+            setReplyTo(null); // 답글 모드 해제
+        } else {
+            // 일반 댓글 등록
+            const newComment = {
+                id: Date.now(),
+                content: comment,
+                author,
+                time: new Date().toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}),
+                replies: [],
+            };
+            const newComments = [...comments, newComment];
+            saveComments(newComments);
+        }
+        setComment("");
+    };
+
+    // 댓글 수정/삭제/대댓글 관련
+    const handleEditComment = (id, content) => {
+        setEditingCommentId(id);
+        setEditingContent(content);
+        setShowCommentMenu(null); // 삼점바 닫기
+    };
+
+    const handleSaveCommentEdit = (id) => {
+        const newComments = comments.map(c => c.id === id ? {...c, content: editingContent} : c);
+        saveComments(newComments);
+        setEditingCommentId(null);
+        setEditingContent("");
+    };
+
+    const handleDeleteComment = (id) => {
+        const newComments = comments.filter(c => c.id !== id);
+        saveComments(newComments);
+    };
+    const handleEditReply = (parentId, replyId, content) => {
+        setEditingCommentId(`${parentId}_${replyId}`);
+        setEditingContent(content);
+        setShowReplyMenu(null); // 삼점바 닫기
+    };
+    const handleSaveEditReply = (parentId, replyId) => {
+        const newComments = comments.map(c => {
+            if (c.id === parentId) {
+                return {
+                    ...c,
+                    replies: c.replies.map(r => r.id === replyId ? {...r, content: editingContent} : r)
+                };
+            }
+            return c;
+        });
+        saveComments(newComments);
+        setEditingCommentId(null);
+        setEditingContent("");
+    };
+    const handleDeleteReply = (parentId, replyId) => {
+        const newComments = comments.map(c => {
+            if (c.id === parentId) {
+                return {
+                    ...c,
+                    replies: c.replies.filter(r => r.id !== replyId)
+                };
+            }
+            return c;
+        });
+        saveComments(newComments);
+    };
+
+    // 게시글 작성자 확인 함수
+    const isAuthor = (author) => {
+        if (!currentUser) return false;
+        return author === currentUser.nickname || author === currentUser.name;
+    };
+
+    if (!post) {
+        return <div>게시글을 찾을 수 없습니다.</div>;
     }
-    setComment("");
-  };
 
-  // 댓글 수정/삭제/대댓글 관련
-  const handleEditComment = (id, content) => {
-    setEditingCommentId(id);
-    setEditingContent(content);
-    setShowCommentMenu(null); // 삼점바 닫기
-  };
+    const handleEdit = () => {
+        navigate('/community/write', {
+            state: {
+                post: post,
+                isEditing: true
+            }
+        });
+        setShowMenu(false);
+    };
 
-  const handleSaveCommentEdit = (id) => {
-    const newComments = comments.map(c => c.id === id ? {...c, content: editingContent} : c);
-    saveComments(newComments);
-    setEditingCommentId(null);
-    setEditingContent("");
-  };
+    const handleDelete = () => {
+        // localStorage에서 삭제 (샘플 데이터가 아닌 localStorage 데이터만)
+        const prev = JSON.parse(localStorage.getItem('communityPosts')) || [];
+        const updated = prev.filter(p => String(p.id) !== String(post.id));
+        localStorage.setItem('communityPosts', JSON.stringify(updated));
+        setShowPostMenu(false); // 메뉴 닫기
+        navigate('/community');
+    };
 
-  const handleDeleteComment = (id) => {
-    const newComments = comments.filter(c => c.id !== id);
-    saveComments(newComments);
-  };
-  const handleEditReply = (parentId, replyId, content) => {
-    setEditingCommentId(`${parentId}_${replyId}`);
-    setEditingContent(content);
-    setShowReplyMenu(null); // 삼점바 닫기
-  };
-  const handleSaveEditReply = (parentId, replyId) => {
-    const newComments = comments.map(c => {
-      if (c.id === parentId) {
-        return {
-          ...c,
-          replies: c.replies.map(r => r.id === replyId ? {...r, content: editingContent} : r)
-        };
-      }
-      return c;
-    });
-    saveComments(newComments);
-    setEditingCommentId(null);
-    setEditingContent("");
-  };
-  const handleDeleteReply = (parentId, replyId) => {
-    const newComments = comments.map(c => {
-      if (c.id === parentId) {
-        return {
-          ...c,
-          replies: c.replies.filter(r => r.id !== replyId)
-        };
-      }
-      return c;
-    });
-    saveComments(newComments);
-  };
+    const handleBack = () => {
+        navigate('/community', {state: {team: post.team}});
+    };
 
-  // 게시글 작성자 확인 함수
-  const isAuthor = (author) => {
-    if (!currentUser) return false;
-    return author === currentUser.nickname || author === currentUser.name;
-  };
+    const toggleMenu = () => {
+        setShowMenu(!showMenu);
+    };
 
-  if (!post) {
-    return <div>게시글을 찾을 수 없습니다.</div>;
-  }
-
-  const handleEdit = () => {
-    navigate('/community/write', { 
-      state: { 
-        post: post,
-        isEditing: true 
-      }
-    });
-    setShowMenu(false);
-  };
-
-  const handleDelete = () => {
-    // localStorage에서 삭제 (샘플 데이터가 아닌 localStorage 데이터만)
-    const prev = JSON.parse(localStorage.getItem('communityPosts')) || [];
-    const updated = prev.filter(p => String(p.id) !== String(post.id));
-    localStorage.setItem('communityPosts', JSON.stringify(updated));
-    setShowPostMenu(false); // 메뉴 닫기
-    navigate('/community');
-  };
-
-  const handleBack = () => {
-    navigate('/community', { state: { team: post.team } });
-  };
-
-  const toggleMenu = () => {
-    setShowMenu(!showMenu);
-  };
-
-  return (
-    <div className={styles.detailWrapper}>
-      {/* 상단바 */}
-      <div className={styles.topBar}>
-        <button className={styles.backBtn} onClick={handleBack}>
-          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <path d="M16 5L9 12L16 19" stroke="#111" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/>
-          </svg>
-        </button>
-        <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_${teamLogoMap[post.team] || 'HH'}.png`} alt="팀로고" className={styles.teamLogo} />
-        <span className={styles.teamName}>{post.teamName || '한화 이글스'}</span>
-      </div>
-      {/* 게시글 카드 */}
-      <div className={styles.card}>
-        <div className={styles.titleRow}>
-          <h2 className={styles.title}>{post.title}</h2>
-          <div className={styles.profileBox}>
-            <img className={styles.profileImg} src={`${process.env.PUBLIC_URL}/profile/user2.jpg`} alt="프로필" />
-            <span className={styles.profileName}>{post.author}</span>
-            {isAuthor && (
-              <div className={styles.menuWrapper}>
-                <button className={styles.menuButton} onClick={toggleMenu}>⋮</button>
-                {showMenu && (
-                  <div className={styles.menuPopup}>
-                    <div className={styles.menuItem} onClick={handleEdit}>수정하기</div>
-                    <div className={`${styles.menuItem} ${styles.delete}`} onClick={handleDelete}>삭제하기</div>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-        </div>
-        {post.image && (
-          <div className={styles.imageWrapper}>
-            <img src={post.image} alt="게시글 이미지" className={styles.postImage} />
-          </div>
-        )}
-        <p className={styles.body}>{post.content}</p>
-      </div>
-      {/* 댓글 영역 */}
-      <div className={styles.commentSection}>
-        <div className={styles.commentList}>
-          {comments.map((c) => (
-            <div key={c.id} className={styles.commentItem}>
-              <div className={styles.commentTop}>
-                <div className={styles.commentProfile}>
-                  <img className={styles.commentProfileImg} src={`${process.env.PUBLIC_URL}/profile/user2.jpg`} alt="프로필" />
-                  <span className={styles.commentAuthor}>{c.author}</span>
-                </div>
-                <div className={styles.commentRight}>
-                  <span className={styles.commentTime}>{c.time}</span>
-                  {isAuthor(c.author) && (
-                    <div className={styles.menuWrapper}>
-                      <button onClick={() => setShowCommentMenu(showCommentMenu === c.id ? null : c.id)} className={styles.menuButton}>⋮</button>
-                      {showCommentMenu === c.id && (
-                        <div className={styles.menuPopup}>
-                          <div className={styles.menuItem} onClick={() => handleEditComment(c.id, c.content)}>수정하기</div>
-                          <div className={styles.menuItem} onClick={() => handleDeleteComment(c.id)}>삭제하기</div>
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              </div>
-              {editingCommentId === c.id ? (
-                <div className={styles.editBox}>
-                  <input value={editingContent} onChange={e => setEditingContent(e.target.value)} />
-                  <button onClick={() => handleSaveCommentEdit(c.id)}>저장</button>
-                </div>
-              ) : (
-                <div className={styles.commentContent}>{c.content}</div>
-              )}
-              {/* 답글쓰기 버튼 */}
-              <div className={styles.replyWriteRow}>
-                <button className={styles.replyBtn} onClick={() => handleReplyClick(c.id)}>답글쓰기</button>
-              </div>
-              {/* 대댓글 */}
-              <div className={styles.replySection}>
-                {c.replies && c.replies.map(r => (
-                  <div key={r.id} className={styles.replyItem}>
-                    <div className={styles.replyRow}>
-                      <div className={styles.commentProfile}>
-                        <img className={styles.commentProfileImg} src={`${process.env.PUBLIC_URL}/profile/user2.jpg`} alt="프로필" />
-                        <span className={styles.commentAuthor}>{r.author}</span>
-                      </div>
-                      <div className={styles.replyRight}>
-                        <span className={styles.commentTime}>{r.time}</span>
-                        {isAuthor(r.author) && (
-                          <div className={styles.menuWrapper}>
-                            <button onClick={() => setShowReplyMenu(showReplyMenu === `${c.id}_${r.id}` ? null : `${c.id}_${r.id}`)} className={styles.menuButton}>⋮</button>
-                            {showReplyMenu === `${c.id}_${r.id}` && (
-                              <div className={styles.menuPopup}>
-                                <div className={styles.menuItem} onClick={() => handleEditReply(c.id, r.id, r.content)}>수정하기</div>
-                                <div className={styles.menuItem} onClick={() => handleDeleteReply(c.id, r.id)}>삭제하기</div>
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                    {editingCommentId === `${c.id}_${r.id}` ? (
-                      <div className={styles.editBox}>
-                        <input value={editingContent} onChange={e => setEditingContent(e.target.value)} />
-                        <button onClick={() => handleSaveEditReply(c.id, r.id)}>저장</button>
-                      </div>
-                    ) : (
-                      <div className={styles.commentContent}>{r.content}</div>
-                    )}
-                  </div>
-                ))}
-              </div>
+    return (
+        <div className={styles.detailWrapper}>
+            {/* 상단바 */}
+            <div className={styles.topBar}>
+                <button className={styles.backBtn} onClick={handleBack}>
+                    <svg width="28" height="28" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M16 5L9 12L16 19" stroke="#111" strokeWidth="2.2" strokeLinecap="round"
+                              strokeLinejoin="round"/>
+                    </svg>
+                </button>
+                <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_${teamLogoMap[post.team] || 'HH'}.png`}
+                     alt="팀로고" className={styles.teamLogo}/>
+                <span className={styles.teamName}>{post.teamName || '한화 이글스'}</span>
             </div>
-          ))}
+            {/* 게시글 카드 */}
+            <div className={styles.card}>
+                <div className={styles.titleRow}>
+                    <h2 className={styles.title}>{post.title}</h2>
+                    <div className={styles.profileBox}>
+                        <img className={styles.profileImg} src={`${process.env.PUBLIC_URL}/profile/user2.jpg`}
+                             alt="프로필"/>
+                        <span className={styles.profileName}>{post.author}</span>
+                        {isAuthor && (
+                            <div className={styles.menuWrapper}>
+                                <button className={styles.menuButton} onClick={toggleMenu}>⋮</button>
+                                {showMenu && (
+                                    <div className={styles.menuPopup}>
+                                        <div className={styles.menuItem} onClick={handleEdit}>수정하기</div>
+                                        <div className={`${styles.menuItem} ${styles.delete}`}
+                                             onClick={handleDelete}>삭제하기
+                                        </div>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                    </div>
+                </div>
+                {post.image && (
+                    <div className={styles.imageWrapper}>
+                        <img src={post.image} alt="게시글 이미지" className={styles.postImage}/>
+                    </div>
+                )}
+                <p className={styles.body}>{post.content}</p>
+            </div>
+            {/* 댓글 영역 */}
+            <div className={styles.commentSection}>
+                <div className={styles.commentList}>
+                    {comments.map((c) => (
+                        <div key={c.id} className={styles.commentItem}>
+                            <div className={styles.commentTop}>
+                                <div className={styles.commentProfile}>
+                                    <img className={styles.commentProfileImg}
+                                         src={`${process.env.PUBLIC_URL}/profile/user2.jpg`} alt="프로필"/>
+                                    <span className={styles.commentAuthor}>{c.author}</span>
+                                </div>
+                                <div className={styles.commentRight}>
+                                    <span className={styles.commentTime}>{c.time}</span>
+                                    {isAuthor(c.author) && (
+                                        <div className={styles.menuWrapper}>
+                                            <button
+                                                onClick={() => setShowCommentMenu(showCommentMenu === c.id ? null : c.id)}
+                                                className={styles.menuButton}>⋮
+                                            </button>
+                                            {showCommentMenu === c.id && (
+                                                <div className={styles.menuPopup}>
+                                                    <div className={styles.menuItem}
+                                                         onClick={() => handleEditComment(c.id, c.content)}>수정하기
+                                                    </div>
+                                                    <div className={styles.menuItem}
+                                                         onClick={() => handleDeleteComment(c.id)}>삭제하기
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                            {editingCommentId === c.id ? (
+                                <div className={styles.editBox}>
+                                    <input value={editingContent} onChange={e => setEditingContent(e.target.value)}/>
+                                    <button onClick={() => handleSaveCommentEdit(c.id)}>저장</button>
+                                </div>
+                            ) : (
+                                <div className={styles.commentContent}>{c.content}</div>
+                            )}
+                            {/* 답글쓰기 버튼 */}
+                            <div className={styles.replyWriteRow}>
+                                <button className={styles.replyBtn} onClick={() => handleReplyClick(c.id)}>답글쓰기</button>
+                            </div>
+                            {/* 대댓글 */}
+                            <div className={styles.replySection}>
+                                {c.replies && c.replies.map(r => (
+                                    <div key={r.id} className={styles.replyItem}>
+                                        <div className={styles.replyRow}>
+                                            <div className={styles.commentProfile}>
+                                                <img className={styles.commentProfileImg}
+                                                     src={`${process.env.PUBLIC_URL}/exImage.png`} alt="프로필"/>
+                                                <span className={styles.commentAuthor}>{r.author}</span>
+                                            </div>
+                                            <div className={styles.replyRight}>
+                                                <span className={styles.commentTime}>{r.time}</span>
+                                                {isAuthor(r.author) && (
+                                                    <div className={styles.menuWrapper}>
+                                                        <button
+                                                            onClick={() => setShowReplyMenu(showReplyMenu === `${c.id}_${r.id}` ? null : `${c.id}_${r.id}`)}
+                                                            className={styles.menuButton}>⋮
+                                                        </button>
+                                                        {showReplyMenu === `${c.id}_${r.id}` && (
+                                                            <div className={styles.menuPopup}>
+                                                                <div className={styles.menuItem}
+                                                                     onClick={() => handleEditReply(c.id, r.id, r.content)}>수정하기
+                                                                </div>
+                                                                <div className={styles.menuItem}
+                                                                     onClick={() => handleDeleteReply(c.id, r.id)}>삭제하기
+                                                                </div>
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </div>
+                                        {editingCommentId === `${c.id}_${r.id}` ? (
+                                            <div className={styles.editBox}>
+                                                <input value={editingContent}
+                                                       onChange={e => setEditingContent(e.target.value)}/>
+                                                <button onClick={() => handleSaveEditReply(c.id, r.id)}>저장</button>
+                                            </div>
+                                        ) : (
+                                            <div className={styles.commentContent}>{r.content}</div>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
+                {/* 댓글 입력창 */}
+                <div className={styles.commentInputBox}>
+                    <input
+                        ref={commentInputRef}
+                        className={styles.commentInput}
+                        value={comment}
+                        onChange={e => setComment(e.target.value)}
+                        placeholder={replyTo ? "답글을 입력하세요" : "댓글을 남겨보세요"}
+                    />
+                    <button className={styles.sendBtn} onClick={handleAddComment}>
+                        <img src={`${process.env.PUBLIC_URL}/Button/paperplane.png`} alt="전송" width={24}/>
+                    </button>
+                </div>
+            </div>
+            <CasterbotButton onClick={() => setShowCasterbot(true)}/>
+
+            {showCasterbot && (
+                <CasterbotModal onClose={() => setShowCasterbot(false)}/>
+            )}
         </div>
-        {/* 댓글 입력창 */}
-        <div className={styles.commentInputBox}>
-          <input
-            ref={commentInputRef}
-            className={styles.commentInput}
-            value={comment}
-            onChange={e => setComment(e.target.value)}
-            placeholder={replyTo ? "답글을 입력하세요" : "댓글을 남겨보세요"}
-          />
-          <button className={styles.sendBtn} onClick={handleAddComment}>
-            <img src={`${process.env.PUBLIC_URL}/Button/paperplane.png`} alt="전송" width={24} />
-          </button>
-        </div>
-      </div>
-    </div>
-  );
+    );
 };
 
 export default PostDetail; 

--- a/src/pages/Community/PostWrite.js
+++ b/src/pages/Community/PostWrite.js
@@ -39,17 +39,34 @@ const PostWrite = () => {
         }
     };
 
-    // ABS봇 비속어 감지 함수
-    const checkProfanity = (text) => {
-        // 실제 금지어로 교체하세요
-        const badwords = ['욕1', '욕2', '욕3'];
-        const found = badwords.find(word => text.includes(word));
-        if (found) {
-            setProfanityMessage(`감지된 비속어: ${found}`);
-            setShowAbsModal(true);
-            return true;
+    // ABS봇 비속어 감지 함수 (API 호출)
+    const checkProfanity = async (text) => {
+        if (!text) return false;
+        try {
+            const response = await fetch('https://xrnfbckpskycrstm.tunnel.elice.io/detect', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({ sentence: text }),
+            });
+            if (!response.ok) {
+                console.error('Profanity API 호출 실패:', response.statusText);
+                return false;
+            }
+            const data = await response.json();
+            const resultString = data.result.replace(/```json\n|```/g, '');
+            const result = JSON.parse(resultString);
+            if (result.is_curse) {
+                setProfanityMessage(`감지된 비속어: ${result.words.join(', ')}`);
+                setShowAbsModal(true);
+                return true;
+            }
+            return false;
+        } catch (error) {
+            console.error('Profanity API 호출 중 오류 발생:', error);
+            return false;
         }
-        return false;
     };
 
     const handleSubmit = async (e) => {
@@ -201,8 +218,17 @@ const PostWrite = () => {
             </form>
             {showAbsModal && (
                 <Modal
-                    title="ABS봇 작동중!"
-                    message={`ABS봇이 부적절한 키워드를 감지했습니다.\n작성글을 수정해 주세요.\n${profanityMessage}`}
+                    title="ABS봇이 작동중입니다."
+                    message={
+                        <>
+                            ABS봇이 부적절한 키워드를 감지했습니다.
+                            <br/>
+                            작성글을 수정해 주세요.
+                            <br/>
+                            <br />
+                            감지된 단어: {profanityMessage}
+                        </>
+                    }
                     buttons={[
                         {
                             label: '확인',

--- a/src/pages/Community/PostWrite.js
+++ b/src/pages/Community/PostWrite.js
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import React, {useEffect, useState} from 'react';
+import {useLocation, useNavigate} from 'react-router-dom';
 import styles from './PostWrite.module.css';
 import Modal from '../../components/Modal/Modal';
+import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import CasterbotModal from "../Chatbot/CasterbotModal";
 
 const PostWrite = () => {
     const navigate = useNavigate();
@@ -17,7 +19,8 @@ const PostWrite = () => {
     const selectedTeam = location.state?.team || 'hanwha';
     const [showAbsModal, setShowAbsModal] = useState(false);
     const [profanityMessage, setProfanityMessage] = useState('');
-    
+    const [showCasterbot, setShowCasterbot] = useState(false);
+
 
     useEffect(() => {
         if (post) {
@@ -56,7 +59,7 @@ const PostWrite = () => {
             return;
         }
         const now = new Date();
-        
+
         // 사용자 정보 검증
         let user = null;
         try {
@@ -71,16 +74,16 @@ const PostWrite = () => {
             console.error('사용자 정보를 불러오는 중 오류가 발생했습니다:', error);
             user = null;
         }
-        
+
         const author = user?.nickname || user?.name || '익명';
-        
+
         // 날짜/시간 형식 현지화
         const date = now.toLocaleDateString('ko-KR', {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit'
         }).replace(/\. /g, '.').replace('.', '');
-        
+
         const time = now.toLocaleTimeString('ko-KR', {
             hour: '2-digit',
             minute: '2-digit',
@@ -142,7 +145,7 @@ const PostWrite = () => {
                 alert('게시물을 저장하는 중 오류가 발생했습니다.');
                 return;
             }
-            navigate('/community', { state: { team: selectedTeam } });
+            navigate('/community', {state: {team: selectedTeam}});
         }
     };
 
@@ -156,7 +159,8 @@ const PostWrite = () => {
                 <span className={styles.headerTitle}>{isEditing ? '게시글 수정' : '게시글 작성'}</span>
                 <button className={styles.closeButton} onClick={handleClose}>
                     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M18 6L6 18M6 6L18 18" stroke="#111" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/>
+                        <path d="M18 6L6 18M6 6L18 18" stroke="#111" strokeWidth="2" strokeLinecap="round"
+                              strokeLinejoin="round"/>
                     </svg>
                 </button>
             </div>
@@ -167,7 +171,7 @@ const PostWrite = () => {
                     ) : (
                         <span>사진/동영상</span>
                     )}
-                    <input type="file" accept="image/*" onChange={handleImageChange} hidden />
+                    <input type="file" accept="image/*" onChange={handleImageChange} hidden/>
                 </label>
                 <div className={styles.formGroup}>
                     <input
@@ -206,6 +210,11 @@ const PostWrite = () => {
                         }
                     ]}
                 />
+            )}
+            <CasterbotButton onClick={() => setShowCasterbot(true)}/>
+
+            {showCasterbot && (
+                <CasterbotModal onClose={() => setShowCasterbot(false)}/>
             )}
         </div>
     );

--- a/src/pages/InitialProfile/TeamChoice.js
+++ b/src/pages/InitialProfile/TeamChoice.js
@@ -44,16 +44,16 @@ const TeamChoice = () => {
 
                 <div className={styles.team_grid}>
                     {[
-                        {id: 8, teamId: 'LG Twins', name: 'LG', logo: 'emblem_LG.png'},
-                        {id: 5, teamId: 'Kia Tigers', name: 'KIA', logo: 'emblem_HT.png'},
-                        {id: 7, teamId: 'Lotte Giants', name: '롯데', logo: 'emblem_LT.png'},
-                        {id: 4, teamId: 'Hanhwa Eagles', name: '한화', logo: 'emblem_HH.png'},
+                        {id: 1, teamId: 'NC Dinos', name: 'NC', logo: 'emblem_NC.png'},
                         {id: 2, teamId: 'Samsung Lions', name: '삼성', logo: 'emblem_SS.png'},
                         {id: 3, teamId: 'Doosan Bears', name: '두산', logo: 'emblem_OB.png'},
-                        {id: 9, teamId: 'SSG Landers', name: 'SSG', logo: 'emblem_SK.png'},
-                        {id: 1, teamId: 'NC Dinos', name: 'NC', logo: 'emblem_NC.png'},
-                        {id: 10, teamId: 'Kiwoom Heroes', name: '키움', logo: 'emblem_WO.png'},
+                        {id: 4, teamId: 'Hanhwa Eagles', name: '한화', logo: 'emblem_HH.png'},
+                        {id: 5, teamId: 'Kia Tigers', name: 'KIA', logo: 'emblem_HT.png'},
                         {id: 6, teamId: 'KT Wiz', name: 'KT', logo: 'emblem_KT.png'},
+                        {id: 7, teamId: 'Lotte Giants', name: '롯데', logo: 'emblem_LT.png'},
+                        {id: 8, teamId: 'LG Twins', name: 'LG', logo: 'emblem_LG.png'},
+                        {id: 9, teamId: 'SSG Landers', name: 'SSG', logo: 'emblem_SK.png'},
+                        {id: 10, teamId: 'Kiwoom Heroes', name: '키움', logo: 'emblem_WO.png'},
                     ].map((team) => (
                         <div
                             className={`${styles.team_card} ${selectedTeam === team.id ? styles.selected : ''}`}

--- a/src/pages/Main/MainPage.js
+++ b/src/pages/Main/MainPage.js
@@ -1,8 +1,10 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import ScheduleSection from "./ScheduleSection";
 import PopularPost from "./PopularPost";
 import MyPartyCard from "./MyPartyCard";
 import styles from "./MainPage.module.css";
+import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import CasterbotModal from "../Chatbot/CasterbotModal";
 
 const sampleData = {
   "NC 다이노스": {
@@ -50,6 +52,7 @@ const sampleData = {
 export default function MainPage() {
   const selectedTeam = "NC 다이노스"; // 기본값으로 NC 다이노스 선택
   const { schedule, posts, parties } = sampleData[selectedTeam];
+  const [showCasterbot, setShowCasterbot] = useState(false);
 
   return (
     <div className={styles.main_page}>
@@ -69,6 +72,12 @@ export default function MainPage() {
       ) : (
         <p className="text-sm text-gray-500">등록된 직관팟이 없습니다.</p>
       )}
+      <CasterbotButton onClick={() => setShowCasterbot(true)} />
+
+      {showCasterbot && (
+          <CasterbotModal onClose={() => setShowCasterbot(false)}/>
+      )}
     </div>
+
   );
 }

--- a/src/pages/Party/PartyMake.js
+++ b/src/pages/Party/PartyMake.js
@@ -130,8 +130,8 @@ const PartyMake = () => {
 
     return (
         <>
-            <input type="file" ref={imageFileRef}/>
-            <button type="button" onClick={handleImageUpload}>이미지 업로드</button>
+            {/*<input type="file" ref={imageFileRef}/>*/}
+            {/*<button type="button" onClick={handleImageUpload}>이미지 업로드</button>*/}
             {step === 1 ? (
                 <PartyFormStep1
                     form={partyForm}

--- a/src/pages/Party/PartyMake.js
+++ b/src/pages/Party/PartyMake.js
@@ -1,58 +1,171 @@
 // 직관팟 작성 페이지
-import React, { useState } from 'react';
+import React, {useRef, useState} from 'react';
+import axios from 'axios';
 import PartyFormStep1 from '../../components/Form/PartyFormStep1';
 import PartyFormStep2 from '../../components/Form/PartyFormStep2';
+import Modal from '../../components/Modal/Modal'; // adjust path if necessary
+
+const getCookie = (name) => {
+    const cookies = document.cookie.split(';').map(cookie => cookie.trim());
+    const found = cookies.find(cookie => cookie.startsWith(`${name}=`));
+    return found ? found.split('=')[1] : null;
+};
 
 const PartyMake = () => {
-  const [step, setStep] = useState(1);
-  const [partyForm, setPartyForm] = useState({
-    partyName: '',
-    applyType: '',
-    gender: '',
-    age: '',
-    min: '',
-    max: '',
-    imageUrls: [],
-    description: '',
-  });
-
-  const handleSubmit = () => {
-    const formData = new FormData();
-    Object.entries(partyForm).forEach(([key, value]) => {
-      if (value !== null) formData.append(key, value);
+    const [step, setStep] = useState(1);
+    const [partyForm, setPartyForm] = useState({
+        partyName: '',
+        applyType: '',
+        gender: '',
+        age: '',
+        min: '',
+        max: '',
+        imageUrls: [],
+        description: '',
+        matchId: '',
     });
 
-    // 이후 백엔드와 연동 시 사용
-    fetch('http://localhost:8080/party', {
-      method: 'POST',
-      body: formData,
-    })
-      .then(res => {
-        if (!res.ok) throw new Error('서버 오류');
-        alert('직관팟이 성공적으로 생성되었습니다!');
-      })
-      .catch(err => {
-        alert('생성 실패: ' + err.message);
-      });
-  };
+    const [modalVisible, setModalVisible] = useState(false);
+    const [modalMessage, setModalMessage] = useState('');
 
-  return (
-    <>
-      {step === 1 ? (
-        <PartyFormStep1
-          form={partyForm}
-          setForm={setPartyForm}
-          onNext={() => setStep(2)}
-        />
-      ) : (
-        <PartyFormStep2
-          form={partyForm}
-          setForm={setPartyForm}
-          onSubmit={handleSubmit}
-        />
-      )}
-    </>
-  );
+    const imageFileRef = useRef();
+
+    const handleImageUpload = async () => {
+        const file = imageFileRef.current?.files[0];
+        if (!file) return alert('이미지 파일을 선택하세요.');
+
+        try {
+            const {data} = await axios.post('http://localhost:8081/party/presigned-url', {
+                imageFileName: file.name,
+            });
+
+            await axios.put(data.presignedUrl, file, {
+                headers: {
+                    'Content-Type': file.type,
+                },
+            });
+
+            const uploadedUrl = data.presignedUrl.split('?')[0];
+
+            setPartyForm(prev => ({
+                ...prev,
+                imageUrls: [...prev.imageUrls, uploadedUrl],
+            }));
+
+            alert('이미지 업로드 성공');
+        } catch (err) {
+            alert('이미지 업로드 실패: ' + err.message);
+        }
+    };
+
+    const checkProfanity = async (description) => {
+        try {
+            const response = await axios.post(
+                "https://xrnfbckpskycrstm.tunnel.elice.io/detect",
+                {sentence: description},
+                {headers: {'Content-Type': 'application/json'}}
+            );
+            const raw = response.data.result
+                .replace(/```json\n/, '')
+                .replace(/`{3,}[\s\S]*$/, '')
+                .trim();
+
+            const parsed = JSON.parse(raw);
+            const isCurse = String(parsed.is_curse).toLowerCase() === 'true';
+            if (isCurse) {
+                const detectedWords = parsed.words || [];
+                setModalMessage(detectedWords.join(', '));
+                return false;
+            }
+            return true;
+
+        } catch (error) {
+            console.error('비속어 필터링 오류:', error);
+            return false;
+        }
+    };
+
+    const handleSubmit = async () => {
+        setModalMessage('');
+        const isClean = await checkProfanity(partyForm.message);
+        if (!isClean) {
+            setModalVisible(true);
+            return;
+        }
+
+        // const accessToken = getCookie('Access');
+        // console.log('[DEBUG] accessToken:', accessToken);
+        // if (!accessToken) {
+        //   alert('로그인이 필요합니다.');
+        //   return;
+        // }
+
+        const payload = {
+            title: partyForm.partyName,
+            partyJoinMethod: partyForm.applyType,
+            partyGender: partyForm.gender,
+            ageGroup: partyForm.age,
+            minimumParticipants: parseInt(partyForm.min),
+            maximumParticipants: parseInt(partyForm.max),
+            thumbnailUrl: partyForm.imageUrls,
+            message: partyForm.description,
+            matchId: partyForm.matchId,
+        };
+
+        try {
+            const response = await axios.post('http://localhost:8081/party', payload, {
+                withCredentials: true,
+                headers: {
+                    // Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/json',
+                },
+            });
+
+            alert('직관팟이 성공적으로 생성되었습니다!');
+            console.log('Created Party:', response.data);
+        } catch (err) {
+            alert('생성 실패: ' + err.message);
+        }
+    };
+
+    return (
+        <>
+            <input type="file" ref={imageFileRef}/>
+            <button type="button" onClick={handleImageUpload}>이미지 업로드</button>
+            {step === 1 ? (
+                <PartyFormStep1
+                    form={partyForm}
+                    setForm={setPartyForm}
+                    onNext={() => setStep(2)}
+                />
+            ) : (
+                <PartyFormStep2
+                    form={partyForm}
+                    setForm={setPartyForm}
+                    onSubmit={handleSubmit}
+                />
+            )}
+            {modalVisible && (
+                <Modal
+                    title="ABS봇이 작동중입니다."
+                    message={
+                        <>
+                            ABS봇이 부적절한 키워드를 감지했습니다.
+                            <br/>
+                            작성글을 수정해 주세요.
+                            <br/>
+                            <br />
+                            감지된 단어: {modalMessage}
+                        </>
+                    }
+                    buttons={[
+                        {label: '확인', onClick: () => setModalVisible(false)}
+                    ]}
+                    onClose={() => setModalVisible(false)}
+                />
+            )}
+        </>
+    );
 };
 
 export default PartyMake;

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 import {Doughnut} from 'react-chartjs-2';
 import {ArcElement, Chart as ChartJS, Legend, Tooltip} from 'chart.js';
 import dummyDiaries from '../../components/DummyData/dummyDiaries';
@@ -38,43 +38,13 @@ const Profile = () => {
     const [searchParams] = useSearchParams();
     const userId = searchParams.get('userId');
     const currentUserId = '1';
-    /*
-    // Move dummyUsers into state with joined and diaryCount added to each user
-    const [dummyUsers] = useState({
-        '1': {
-            nickname: 'ZSJ',
-            email: 'cho010105@gachon.ac.kr',
-            teamLogo: 'NC',
-            profileImg: `${process.env.PUBLIC_URL}/Logo/default.png`,
-            joined: '2025년 3월 13일',
-        },
-        '2': {
-            nickname: '다른유저',
-            email: 'user2@example.com',
-            teamLogo: 'HH',
-            profileImg: `${process.env.PUBLIC_URL}/Logo/profile.png`,
-            joined: '2025년 1월 20일',
-        }
-    });
-    const targetId = userId || currentUserId;
-    // Set diaryCount dynamically from allDiaries, and merge with profile data
-    const profileBase = dummyUsers[targetId];
-    const diaryCount = allDiaries.filter(d => d.userId === targetId).length;
-    const profile = {
-        ...profileBase,
-        diaryCount
-    };
-    const isMine = !userId || userId === currentUserId;
 
-    const [nickname, setNickname] = useState(profile.nickname);
-    */
     const [profile, setProfile] = useState(null);
     const [nickname, setNickname] = useState('');
     const [isMine, setIsMine] = useState(false);
 
 
     useEffect(() => {
-        // 수정된 fetchProfile 부분
         const fetchProfile = async () => {
             const endpoint = `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/profile`;
 
@@ -84,7 +54,28 @@ const Profile = () => {
                 });
 
                 const data = res.data;
-                setProfile(data);
+                const favoriteTeams = data.favoriteTeams || [];
+                const primaryTeam = favoriteTeams.find(team => team.displayOrder === 1);
+
+                const teamLogoMap = {
+                    1: 'NC',
+                    2: 'SS',
+                    3: 'OB',
+                    4: 'HH',
+                    5: 'HT',
+                    6: 'KT',
+                    7: 'LT',
+                    8: 'LG',
+                    9: 'SK',
+                    10: 'WO'
+                };
+                const logoPrefix = teamLogoMap[primaryTeam?.teamId] || 'default';
+                const teamLogo = `TeamLogo/emblem_${logoPrefix}.png`;
+
+                setProfile({
+                    ...data,
+                    teamLogo
+                });
                 setNickname(data.nickname);
                 setIsMine(true);
             } catch (err) {
@@ -166,12 +157,13 @@ const Profile = () => {
                                             <img src={`${process.env.PUBLIC_URL}/Button/logout.png`} alt="logout"
                                                  className={styles.logoutImg}/>로그아웃
                                         </div>
-                                        <div className={styles.withdrawal} onClick={() => setShowWithdrawalModal(true)}>탈퇴하기
+                                        <div className={styles.withdrawal}
+                                             onClick={() => setShowWithdrawalModal(true)}>탈퇴하기
                                         </div>
                                     </>
                                 )}
                             </div>
-                            <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo_Big/${profile.teamLogo}.png`} alt="team"
+                            <img src={`${process.env.PUBLIC_URL}/Logo/${profile.teamLogo}`} alt="team"
                                  className={styles.teamImg}/>
                         </header>
 

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -77,7 +77,7 @@ const Profile = () => {
                     teamLogo
                 });
                 setNickname(data.nickname);
-                setIsMine(true);
+                setIsMine(!userId || userId === String(data.userId));
             } catch (err) {
                 console.error('프로필 불러오기 오류:', err);
             }
@@ -309,7 +309,10 @@ const Profile = () => {
                 {showProfileEditModal && (
                     <ProfileEditModal
                         onClose={() => setShowProfileEditModal(false)}
-                        onSubmit={(newNickname) => setNickname(newNickname)}
+                        onSubmit={(newNickname) => {
+                            setNickname(newNickname);
+                            setProfile(prev => ({ ...prev, nickname: newNickname }));
+                        }}
                         initialNickname={nickname}
                     />
                 )}

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -42,7 +42,7 @@ const Profile = () => {
     const [profile, setProfile] = useState(null);
     const [nickname, setNickname] = useState('');
     const [isMine, setIsMine] = useState(false);
-
+    const [error, setError] = useState(null);
 
     useEffect(() => {
         const fetchProfile = async () => {
@@ -80,6 +80,7 @@ const Profile = () => {
                 setIsMine(!userId || userId === String(data.userId));
             } catch (err) {
                 console.error('프로필 불러오기 오류:', err);
+                setError('프로필을 불러오는 중 오류가 발생했습니다. 다시 시도해주세요.');
             }
         };
 
@@ -128,6 +129,21 @@ const Profile = () => {
     return (
         <>
             <div className={styles.container}>
+
+                {error && (
+                    <Modal
+                        title="에러 발생"
+                        message={error}
+                        buttons={[
+                            {
+                                label: '확인',
+                                onClick: () => setError(null)
+                            }
+                        ]}
+                        onClose={() => setError(null)}
+                    />
+                )}
+
                 {profile && (
                     <>
                         <header className={styles.header}>
@@ -311,7 +327,7 @@ const Profile = () => {
                         onClose={() => setShowProfileEditModal(false)}
                         onSubmit={(newNickname) => {
                             setNickname(newNickname);
-                            setProfile(prev => ({ ...prev, nickname: newNickname }));
+                            setProfile(prev => ({...prev, nickname: newNickname}));
                         }}
                         initialNickname={nickname}
                     />

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -131,7 +131,15 @@ const Profile = () => {
                 {profile && (
                     <>
                         <header className={styles.header}>
-                            <img src={profile.profileImg} alt="profile" className={styles.profileImg}/>
+                            <img
+                                src={
+                                    !profile.profileImg || profile.profileImg.includes('default.png')
+                                        ? `${process.env.PUBLIC_URL}/profile/user2.jpg`
+                                        : profile.profileImg
+                                }
+                                alt="profile"
+                                className={styles.profileImg}
+                            />
                             <div className={styles.userInfo}>
                                 <div className={styles.username}>
                                     <span>{profile.nickname}</span>

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {Doughnut} from 'react-chartjs-2';
 import {ArcElement, Chart as ChartJS, Legend, Tooltip} from 'chart.js';
 import dummyDiaries from '../../components/DummyData/dummyDiaries';
@@ -12,6 +12,7 @@ import ProfileEditModal from '../../components/Modal/ProfileEditModal/ProfileEdi
 import WithdrawalModal from '../../components/Modal/WithdrawalModal/WithdrawalModal';
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import axios from "axios";
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 const storedDiaries = JSON.parse(localStorage.getItem('customDiaries')) || [];
@@ -37,6 +38,7 @@ const Profile = () => {
     const [searchParams] = useSearchParams();
     const userId = searchParams.get('userId');
     const currentUserId = '1';
+    /*
     // Move dummyUsers into state with joined and diaryCount added to each user
     const [dummyUsers] = useState({
         '1': {
@@ -64,13 +66,41 @@ const Profile = () => {
     };
     const isMine = !userId || userId === currentUserId;
 
+    const [nickname, setNickname] = useState(profile.nickname);
+    */
+    const [profile, setProfile] = useState(null);
+    const [nickname, setNickname] = useState('');
+    const [isMine, setIsMine] = useState(false);
+
+
+    useEffect(() => {
+        // 수정된 fetchProfile 부분
+        const fetchProfile = async () => {
+            const endpoint = `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/profile`;
+
+            try {
+                const res = await axios.get(endpoint, {
+                    withCredentials: true
+                });
+
+                const data = res.data;
+                setProfile(data);
+                setNickname(data.nickname);
+                setIsMine(true);
+            } catch (err) {
+                console.error('프로필 불러오기 오류:', err);
+            }
+        };
+
+        fetchProfile();
+    }, [userId]);
+
     const today = new Date();
     const [value, setValue] = useState(today);
     const [showLogoutModal, setShowLogoutModal] = useState(false);
     const [showProfileEditModal, setShowProfileEditModal] = useState(false);
     const [showWithdrawalModal, setShowWithdrawalModal] = useState(false);
     const [showFinalModal, setShowFinalModal] = useState(false);
-    const [nickname, setNickname] = useState(profile.nickname);
     const navigate = useNavigate();
     const handleLogout = () => {
         console.log('로그아웃 확인됨');
@@ -107,128 +137,132 @@ const Profile = () => {
     return (
         <>
             <div className={styles.container}>
-                <header className={styles.header}>
-                    <img src={profile.profileImg} alt="profile" className={styles.profileImg}/>
-                    <div className={styles.userInfo}>
-                        <div className={styles.username}>
-                            <span>{profile.nickname}</span>
-                            {isMine && (
-                                <img
-                                    src={`${process.env.PUBLIC_URL}/Button/create.png`}
-                                    alt="edit"
-                                    className={styles.editIcon}
-                                    onClick={() => setShowProfileEditModal(true)}
-                                />
-                            )}
-                        </div>
-                        {isMine ? (
-                            <div className={styles.email}>{profile.email}</div>
-                        ) : (
-                            <div className={styles.email}>
-                                직관일지 {profile.diaryCount}회 작성 · {profile.joined} 가입
+                {profile && (
+                    <>
+                        <header className={styles.header}>
+                            <img src={profile.profileImg} alt="profile" className={styles.profileImg}/>
+                            <div className={styles.userInfo}>
+                                <div className={styles.username}>
+                                    <span>{profile.nickname}</span>
+                                    {isMine && (
+                                        <img
+                                            src={`${process.env.PUBLIC_URL}/Button/create.png`}
+                                            alt="edit"
+                                            className={styles.editIcon}
+                                            onClick={() => setShowProfileEditModal(true)}
+                                        />
+                                    )}
+                                </div>
+                                {isMine ? (
+                                    <div className={styles.email}>{profile.email}</div>
+                                ) : (
+                                    <div className={styles.email}>
+                                        직관일지 {profile.diaryCount}회 작성 · {profile.joined} 가입
+                                    </div>
+                                )}
+                                {isMine && (
+                                    <>
+                                        <div className={styles.logout} onClick={() => setShowLogoutModal(true)}>
+                                            <img src={`${process.env.PUBLIC_URL}/Button/logout.png`} alt="logout"
+                                                 className={styles.logoutImg}/>로그아웃
+                                        </div>
+                                        <div className={styles.withdrawal} onClick={() => setShowWithdrawalModal(true)}>탈퇴하기
+                                        </div>
+                                    </>
+                                )}
                             </div>
-                        )}
-                        {isMine && (
+                            <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo_Big/${profile.teamLogo}.png`} alt="team"
+                                 className={styles.teamImg}/>
+                        </header>
+
+                        {isMine ? (
                             <>
-                                <div className={styles.logout} onClick={() => setShowLogoutModal(true)}>
-                                    <img src={`${process.env.PUBLIC_URL}/Button/logout.png`} alt="logout"
-                                         className={styles.logoutImg}/>로그아웃
-                                </div>
-                                <div className={styles.withdrawal} onClick={() => setShowWithdrawalModal(true)}>탈퇴하기
-                                </div>
+                                <section className={styles.calendarSection}>
+                                    <h2>직관 달력</h2>
+                                    <div className={styles.calendarSectionDiv}>
+                                        <Calendar
+                                            onChange={setValue}
+                                            value={value}
+                                            tileContent={tileContent}
+                                            formatDay={(locale, date) => date.getDate().toString()}
+                                            locale="ko-KR"
+                                        />
+                                    </div>
+                                </section>
+
+                                <section className={styles.journalSection}>
+                                    <div className={styles.journalHeader}>
+                                        <h2>이번 달 나의 직관일지</h2>
+                                        <button className={styles.writeBtn} onClick={handleNewDiary}>직관일지 작성하기</button>
+                                        <div className={styles.logout} onClick={handleDiaryList}>더보기</div>
+                                    </div>
+                                    <ul className={styles.journalList}>
+                                        {journalEntries.map((entry, idx) => (
+                                            <li key={idx} className={styles.journalItem}>
+                                                {entry.image &&
+                                                    <img src={entry.image} alt="entry" className={styles.entryImg}/>}
+                                                <span className={styles.entryTitle}>{entry.title}</span>
+                                                <span className={styles.entryDate}>{entry.date}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </section>
+                            </>
+                        ) : (
+                            <>
+                                <section className={styles.accuracySection}>
+                                    <h2>직관 타율</h2>
+                                    <div className={styles.accuracyChartWrapper}>
+                                        <div className={styles.accuracyCircle}>
+                                            <Doughnut
+                                                data={{
+                                                    labels: ['타율', '빈 공간'],
+                                                    datasets: [
+                                                        {
+                                                            data: [accuracyValue, 100 - accuracyValue],
+                                                            backgroundColor: ['#f66', '#f2f2f2'],
+                                                            borderWidth: 0
+                                                        }
+                                                    ]
+                                                }}
+                                                options={{
+                                                    cutout: '70%',
+                                                    plugins: {
+                                                        legend: {display: false},
+                                                        tooltip: {enabled: false}
+                                                    }
+                                                }}
+                                            />
+                                            <div
+                                                className={styles.accuracyNumberOverlay}>{(accuracyValue / 100).toFixed(3)}</div>
+                                        </div>
+                                        <div className={styles.reviewSummary}>
+                                            <p>100명 중 42명이 직관팟에 만족했어요.</p>
+                                            <div className={styles.reviewTag}>답장이 빨라요.</div>
+                                            <div className={styles.reviewTag}>시간 약속을 잘 지켜요.</div>
+                                            <div className={styles.reviewTag}>경기 직관이 열정적이에요.</div>
+                                        </div>
+                                    </div>
+                                </section>
+
+                                <section className={styles.journalSection}>
+                                    <div className={styles.journalHeader}>
+                                        <h2>최근 커뮤니티 게시글</h2>
+                                        <div className={styles.logout} onClick={handleDiaryList}>더보기</div>
+                                    </div>
+                                    <ul className={styles.journalList}>
+                                        {journalEntries.map((entry, idx) => (
+                                            <li key={idx} className={styles.journalItem}>
+                                                {entry.image &&
+                                                    <img src={entry.image} alt="entry" className={styles.entryImg}/>}
+                                                <span className={styles.entryTitle}>{entry.title}</span>
+                                                <span className={styles.entryDate}>{entry.date}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </section>
                             </>
                         )}
-                    </div>
-                    <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo_Big/${profile.teamLogo}.png`} alt="team"
-                         className={styles.teamImg}/>
-                </header>
-
-                {isMine ? (
-                    <>
-                        <section className={styles.calendarSection}>
-                            <h2>직관 달력</h2>
-                            <div className={styles.calendarSectionDiv}>
-                                <Calendar
-                                    onChange={setValue}
-                                    value={value}
-                                    tileContent={tileContent}
-                                    formatDay={(locale, date) => date.getDate().toString()}
-                                    locale="ko-KR"
-                                />
-                            </div>
-                        </section>
-
-                        <section className={styles.journalSection}>
-                            <div className={styles.journalHeader}>
-                                <h2>이번 달 나의 직관일지</h2>
-                                <button className={styles.writeBtn} onClick={handleNewDiary}>직관일지 작성하기</button>
-                                <div className={styles.logout} onClick={handleDiaryList}>더보기</div>
-                            </div>
-                            <ul className={styles.journalList}>
-                                {journalEntries.map((entry, idx) => (
-                                    <li key={idx} className={styles.journalItem}>
-                                        {entry.image &&
-                                            <img src={entry.image} alt="entry" className={styles.entryImg}/>}
-                                        <span className={styles.entryTitle}>{entry.title}</span>
-                                        <span className={styles.entryDate}>{entry.date}</span>
-                                    </li>
-                                ))}
-                            </ul>
-                        </section>
-                    </>
-                ) : (
-                    <>
-                        <section className={styles.accuracySection}>
-                            <h2>직관 타율</h2>
-                            <div className={styles.accuracyChartWrapper}>
-                                <div className={styles.accuracyCircle}>
-                                    <Doughnut
-                                        data={{
-                                            labels: ['타율', '빈 공간'],
-                                            datasets: [
-                                                {
-                                                    data: [accuracyValue, 100 - accuracyValue],
-                                                    backgroundColor: ['#f66', '#f2f2f2'],
-                                                    borderWidth: 0
-                                                }
-                                            ]
-                                        }}
-                                        options={{
-                                            cutout: '70%',
-                                            plugins: {
-                                                legend: {display: false},
-                                                tooltip: {enabled: false}
-                                            }
-                                        }}
-                                    />
-                                    <div
-                                        className={styles.accuracyNumberOverlay}>{(accuracyValue / 100).toFixed(3)}</div>
-                                </div>
-                                <div className={styles.reviewSummary}>
-                                    <p>100명 중 42명이 직관팟에 만족했어요.</p>
-                                    <div className={styles.reviewTag}>답장이 빨라요.</div>
-                                    <div className={styles.reviewTag}>시간 약속을 잘 지켜요.</div>
-                                    <div className={styles.reviewTag}>경기 직관이 열정적이에요.</div>
-                                </div>
-                            </div>
-                        </section>
-
-                        <section className={styles.journalSection}>
-                            <div className={styles.journalHeader}>
-                                <h2>최근 커뮤니티 게시글</h2>
-                                <div className={styles.logout} onClick={handleDiaryList}>더보기</div>
-                            </div>
-                            <ul className={styles.journalList}>
-                                {journalEntries.map((entry, idx) => (
-                                    <li key={idx} className={styles.journalItem}>
-                                        {entry.image &&
-                                            <img src={entry.image} alt="entry" className={styles.entryImg}/>}
-                                        <span className={styles.entryTitle}>{entry.title}</span>
-                                        <span className={styles.entryDate}>{entry.date}</span>
-                                    </li>
-                                ))}
-                            </ul>
-                        </section>
                     </>
                 )}
                 {showLogoutModal && (
@@ -276,6 +310,7 @@ const Profile = () => {
                     <ProfileEditModal
                         onClose={() => setShowProfileEditModal(false)}
                         onSubmit={(newNickname) => setNickname(newNickname)}
+                        initialNickname={nickname}
                     />
                 )}
             </div>

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -109,24 +109,7 @@ function AppRouter() {
                 <Route path="/diary/:id" element={<MobileView/>}>
                     <Route index element={<DiaryDetail/>}/>
                 </Route>
-                {/* 프로필 & 직관일지 */}
-                {/* 프로필 메인 & 타 사용자 프로필 */}
-                <Route path="/profile" element={<MobileView/>}>
-                    <Route index element={<Profile/>}/>
-                {/* 차후 User Id를 받아 /profile/:userId로 변경 예정 */}
-                </Route>
-                {/* 직관일지 목록 */}
-                <Route path="/diary/list" element={<MobileView/>}>
-                    <Route index element={<DiaryList/>}/>
-                </Route>
-                {/* 직관일지 작성 */}
-                <Route path="/diary/newdiary" element={<MobileView/>}>
-                    <Route index element={<NewDiary/>}/>
-                </Route>
-                {/* 직관일지 상세 */}
-                <Route path="/diary/:id" element={<MobileView/>}>
-                    <Route index element={<DiaryDetail/>}/>
-                </Route>
+                {/* 커뮤니티 게시글 상세 */}
                 <Route path="/community/post/:postId" element={<MobileView />}>
                     <Route index element={<PostDetail />} />
                 </Route>


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 사용자 프로필 조회 API 연결
<img width="299" alt="image" src="https://github.com/user-attachments/assets/5eb7ee27-eb2d-4877-9d9e-b35c688911d7" />
<br/>
<img width="488" alt="image" src="https://github.com/user-attachments/assets/5f80c172-2b52-4675-bf0f-7eb395bc5eb5" />

- 사용자 이미지를 불러오지 못하는 경우 public 경로의 임의 데이터로 표시

### 2. 사용자 닉네임 수정 API 연결
![NickName](https://github.com/user-attachments/assets/84fb6dc9-2c60-4e3b-9180-85f8d2258bbd)
- 현재 사용자 프로필 이미지 관련 로직은 백엔드에서 구현되는 대로 적용 예정
- 닉네임 수정 시 페이지 즉시 렌더링

---

## 🔗 관련 이슈
- closes #45 

---

## 💡 추가 사항
1. 로그아웃 API 구현 필요
2. 타 사용자 정보 조회 로직 구현 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 커뮤니티, 메인, 게시글 상세/작성 페이지에 챗봇(Casterbot) 버튼 및 모달이 추가되었습니다.
    - 커뮤니티 게시글 상세 및 작성, 직관팟 생성 시 부적절한 언어(비속어) 감지 기능이 도입되어, 감지 시 경고 모달이 표시됩니다.
    - 헤더에 알림 모달이 추가되어, 탭별 알림 확인 및 참가요청 승인/거절, 알림 전체 삭제가 가능합니다.

- **기능 개선**
    - 프로필 페이지가 더 이상 더미 데이터가 아닌, 백엔드에서 사용자 정보를 불러오도록 개선되었습니다.
    - 프로필 수정 모달이 닉네임 초기값을 지원하고, 닉네임 변경 시 서버에 반영됩니다.
    - 직관팟 생성 시 이미지 업로드 및 서버 연동이 개선되었습니다.

- **버그 수정 및 UI 개선**
    - 팀 선택 화면에서 팀 순서가 변경되어 새로운 순서로 표시됩니다.
    - 일부 폼 입력값의 명칭이 더 직관적으로 변경되었습니다.
    - 헤더 및 알림 모달, 알림 관련 스타일이 추가 및 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->