### PR TITLE
[FEAT] 직관팟 생성 로직 연결 & presigned URL 이미지 전송 테스트

### DIFF
--- a/src/components/Form/PartyFormStep1.js
+++ b/src/components/Form/PartyFormStep1.js
@@ -34,7 +34,7 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                     title="입력 오류"
                     message={modalMessage}
                     buttons={[
-                        { label: '확인', onClick: () => setModalOpen(false) },
+                        {label: '확인', onClick: () => setModalOpen(false)},
                     ]}
                 />
             )}
@@ -83,12 +83,16 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                             <button
                                 key={age}
                                 className={`${styles.button} ${selected ? styles.buttonActive : ''}`}
-                                onClick={() => {
-                                    const updated = selected
-                                        ? form.ageGroup.filter(a => a !== age)
-                                        : [...(form.ageGroup || []), age];
-                                    handleChange('ageGroup', updated);
-                                }}
+                                onClick={() =>
+                                    setForm(prev => {
+                                        const current = Array.isArray(prev.ageGroup) ? prev.ageGroup : [];
+                                        const already = current.includes(age);
+                                        const updated = already
+                                            ? current.filter(a => a !== age)
+                                            : [...current, age];
+                                        return {...prev, ageGroup: updated};
+                                    })
+                                }
                             >
                                 {age}
                             </button>

--- a/src/components/Form/PartyFormStep1.js
+++ b/src/components/Form/PartyFormStep1.js
@@ -20,7 +20,7 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
             form.title &&
             form.partyJoinMethod &&
             form.partyGender &&
-            form.ageGroup &&
+            Array.isArray(form.ageGroup) && form.ageGroup.length > 0 &&
             form.minimumParticipants &&
             form.maximumParticipants &&
             form.minimumParticipants < form.maximumParticipants
@@ -77,15 +77,23 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
 
                 <h2 className={styles.title}>참여자의 나이를 설정해 주세요.</h2>
                 <div className={`${styles.section} ${styles.flexWrap}`}>
-                    {['10대', '20대', '30대', '40대', '50대', '60대 이상'].map(age => (
-                        <button
-                            key={age}
-                            className={`${styles.button} ${form.ageGroup === age ? styles.buttonActive : ''}`}
-                            onClick={() => handleChange('ageGroup', age)}
-                        >
-                            {age}
-                        </button>
-                    ))}
+                    {['10대', '20대', '30대', '40대', '50대', '60대 이상'].map(age => {
+                        const selected = Array.isArray(form.ageGroup) && form.ageGroup.includes(age);
+                        return (
+                            <button
+                                key={age}
+                                className={`${styles.button} ${selected ? styles.buttonActive : ''}`}
+                                onClick={() => {
+                                    const updated = selected
+                                        ? form.ageGroup.filter(a => a !== age)
+                                        : [...(form.ageGroup || []), age];
+                                    handleChange('ageGroup', updated);
+                                }}
+                            >
+                                {age}
+                            </button>
+                        );
+                    })}
                 </div>
 
                 <h2 className={styles.title}>신청 최대 인원을 설정해 주세요.</h2>
@@ -138,7 +146,7 @@ const PartyFormStep1 = ({form, setForm, onNext}) => {
                             setModalMessage('신청 방식을 선택해 주세요.');
                         } else if (!form.partyGender) {
                             setModalMessage('참여 성별을 선택해 주세요.');
-                        } else if (!form.ageGroup) {
+                        } else if (!Array.isArray(form.ageGroup) || form.ageGroup.length === 0) {
                             setModalMessage('참여자의 나이를 설정해 주세요.');
                         } else if (!form.minimumParticipants || !form.maximumParticipants) {
                             setModalMessage('최소 및 최대 인원을 입력해 주세요.');

--- a/src/components/Form/PartyFormStep2.js
+++ b/src/components/Form/PartyFormStep2.js
@@ -13,46 +13,35 @@ const PartyFormStep2 = ({form, setForm, onSubmit}) => {
         const file = e.target.files[0];
         if (!file) return;
 
-        // 파일 크기 제한 10MB
         if (file.size > 10 * 1024 * 1024) {
-            alert('파일 크기는 5MB 이하여야 합니다.');
+            alert('파일 크기는 10MB 이하여야 합니다.');
             return;
         }
 
-        // 지원되는 이미지 형식 확인
         const validTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
         if (!validTypes.includes(file.type)) {
             alert('JPG, PNG, GIF, WEBP 형식의 이미지만 업로드 가능합니다.');
             return;
         }
 
-        // Do not allow more than 10 images
-        if (Array.isArray(form.imageUrls) && form.imageUrls.length >= 10) {
+        if (Array.isArray(form.thumbnailImageNameList) && form.thumbnailImageNameList.length >= 10) {
             alert('이미지는 최대 10개까지 업로드할 수 있습니다.');
             return;
         }
 
-        setForm(prev => ({...prev, isUploading: true}));
-        const reader = new FileReader();
-        reader.onloadend = () => {
-            const newUrl = reader.result;
-            const updated = Array.isArray(form.imageUrls) ? [...form.imageUrls, newUrl] : [newUrl];
-            handleChange('imageUrls', updated);
-            handleChange('isUploading', false);
-        };
-        reader.onerror = () => {
-            alert('이미지 업로드 중 오류가 발생했습니다.');
-            handleChange('isUploading', false);
-        };
-        reader.readAsDataURL(file);
+        const updated = Array.isArray(form.thumbnailImageNameList)
+            ? [...form.thumbnailImageNameList, file]
+            : [file];
+
+        handleChange('thumbnailImageNameList', updated);
     };
 
     // Remove image at index from imageUrls array
     const removeImageAt = (index) => {
-        if (!Array.isArray(form.imageUrls)) return;
-        const updated = [...form.imageUrls];
+        if (!Array.isArray(form.thumbnailImageNameList)) return;
+        const updated = [...form.thumbnailImageNameList];
         updated.splice(index, 1);
-        handleChange('imageUrls', updated);
+        handleChange('thumbnailImageNameList', updated);
     };
     const [activeTab, setActiveTab] = useState(0);
     const navigate = useNavigate();
@@ -64,7 +53,7 @@ const PartyFormStep2 = ({form, setForm, onSubmit}) => {
             return false;
         }
 
-        if (!Array.isArray(form.imageUrls) || form.imageUrls.length === 0) {
+        if (!Array.isArray(form.thumbnailImageNameList) || form.thumbnailImageNameList.length === 0) {
             alert('최소 1개 이상의 이미지를 업로드해 주세요.');
             return false;
         }
@@ -93,10 +82,10 @@ const PartyFormStep2 = ({form, setForm, onSubmit}) => {
                         onChange={handleThumbnailChange}
                         className={styles.hiddenInput}
                     />
-                    {form.imageUrls && form.imageUrls.length > 0 && form.imageUrls.map((url, index) => (
+                    {form.thumbnailImageNameList && form.thumbnailImageNameList.length > 0 && form.thumbnailImageNameList.map((url, index) => (
                         <div key={index} className={styles.thumbnailWrapper}>
                             <img
-                                src={url}
+                                src={typeof url === 'string' ? url : URL.createObjectURL(url)}
                                 alt={`썸네일 미리보기 ${index + 1}`}
                                 className={styles.thumbnailPreview}
                             />

--- a/src/pages/Party/PartyMake.js
+++ b/src/pages/Party/PartyMake.js
@@ -14,15 +14,15 @@ const getCookie = (name) => {
 const PartyMake = () => {
     const [step, setStep] = useState(1);
     const [partyForm, setPartyForm] = useState({
-        partyName: '',
-        applyType: '',
-        gender: '',
-        age: '',
-        min: '',
-        max: '',
-        imageUrls: [],
-        description: '',
-        matchId: '',
+        title: '',
+        partyJoinMethod: '',
+        partyGender: '',
+        ageGroup: [],
+        minimumParticipants: '',
+        maximumParticipants: '',
+        thumbnailImageNameList: [],
+        message: '',
+        matchId: 1,
     });
 
     const [modalVisible, setModalVisible] = useState(false);
@@ -31,33 +31,10 @@ const PartyMake = () => {
     const imageFileRef = useRef();
 
     const handleImageUpload = async () => {
-        const file = imageFileRef.current?.files[0];
-        if (!file) return alert('이미지 파일을 선택하세요.');
-
-        try {
-            const {data} = await axios.post('http://localhost:8081/party/presigned-url', {
-                imageFileName: file.name,
-            });
-
-            await axios.put(data.presignedUrl, file, {
-                headers: {
-                    'Content-Type': file.type,
-                },
-            });
-
-            const uploadedUrl = data.presignedUrl.split('?')[0];
-
-            setPartyForm(prev => ({
-                ...prev,
-                imageUrls: [...prev.imageUrls, uploadedUrl],
-            }));
-
-            alert('이미지 업로드 성공');
-        } catch (err) {
-            alert('이미지 업로드 실패: ' + err.message);
-        }
+        // This function is no longer used for immediate upload
     };
 
+    /*
     const checkProfanity = async (description) => {
         try {
             const response = await axios.post(
@@ -84,31 +61,46 @@ const PartyMake = () => {
             return false;
         }
     };
+    */
 
     const handleSubmit = async () => {
+        /*
         setModalMessage('');
         const isClean = await checkProfanity(partyForm.message);
         if (!isClean) {
             setModalVisible(true);
             return;
         }
+        */
 
-        // const accessToken = getCookie('Access');
-        // console.log('[DEBUG] accessToken:', accessToken);
-        // if (!accessToken) {
-        //   alert('로그인이 필요합니다.');
-        //   return;
-        // }
+        const uploadedFileNames = [];
+
+        for (const file of partyForm.thumbnailImageNameList) {
+            if (typeof file === 'string') {
+                uploadedFileNames.push(file); // already uploaded
+                continue;
+            }
+
+            const { data } = await axios.post('http://localhost:8081/party/presigned-url', {
+                imageFileName: file.name,
+            }, { withCredentials: true });
+
+            await axios.put(data.presignedUrl, file, {
+                headers: { 'Content-Type': file.type },
+            });
+
+            uploadedFileNames.push(file.name); // store filename only
+        }
 
         const payload = {
-            title: partyForm.partyName,
-            partyJoinMethod: partyForm.applyType,
-            partyGender: partyForm.gender,
-            ageGroup: partyForm.age,
-            minimumParticipants: parseInt(partyForm.min),
-            maximumParticipants: parseInt(partyForm.max),
-            thumbnailUrl: partyForm.imageUrls,
-            message: partyForm.description,
+            title: partyForm.title,
+            partyJoinMethod: partyForm.partyJoinMethod,
+            partyGender: partyForm.partyGender,
+            ageGroup: partyForm.ageGroup,
+            minimumParticipants: parseInt(partyForm.minimumParticipants),
+            maximumParticipants: parseInt(partyForm.maximumParticipants),
+            thumbnailUrl: uploadedFileNames,
+            message: partyForm.message,
             matchId: partyForm.matchId,
         };
 
@@ -145,25 +137,25 @@ const PartyMake = () => {
                     onSubmit={handleSubmit}
                 />
             )}
-            {modalVisible && (
-                <Modal
-                    title="ABS봇이 작동중입니다."
-                    message={
-                        <>
-                            ABS봇이 부적절한 키워드를 감지했습니다.
-                            <br/>
-                            작성글을 수정해 주세요.
-                            <br/>
-                            <br />
-                            감지된 단어: {modalMessage}
-                        </>
-                    }
-                    buttons={[
-                        {label: '확인', onClick: () => setModalVisible(false)}
-                    ]}
-                    onClose={() => setModalVisible(false)}
-                />
-            )}
+            {/*{modalVisible && (*/}
+            {/*    <Modal*/}
+            {/*        title="ABS봇이 작동중입니다."*/}
+            {/*        message={*/}
+            {/*            <>*/}
+            {/*                ABS봇이 부적절한 키워드를 감지했습니다.*/}
+            {/*                <br/>*/}
+            {/*                작성글을 수정해 주세요.*/}
+            {/*                <br/>*/}
+            {/*                <br />*/}
+            {/*                감지된 단어: {modalMessage}*/}
+            {/*            </>*/}
+            {/*        }*/}
+            {/*        buttons={[*/}
+            {/*            {label: '확인', onClick: () => setModalVisible(false)}*/}
+            {/*        ]}*/}
+            {/*        onClose={() => setModalVisible(false)}*/}
+            {/*    />*/}
+            {/*)}*/}
         </>
     );
 };


### PR DESCRIPTION
1. twp-service repository API와 연결하여 직관팟 생성 로직 구현
2. presigned url의 경우 현재 해당 cloud objectStorage로 올라가지 않음 -> 확인 필요

## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 직관팟 생성 확인
<img width="304" alt="image" src="https://github.com/user-attachments/assets/465ce72a-8448-41d7-b0f8-8274d06d4be5" />

- 직관팟 작성 시 Springboot 서버를 거쳐 mongoDB로 데이터가 write되는 것 확인


### 2. Presigned Image 테스트
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/0a036e92-ef0b-46a0-b853-fd67fb56fa6b" />

- FrontEnd에서 사용자가 등록한 이미지명을 BackEnd로 전송하고, 이후 BackEnd에서 Presigned url로 변환해서 return해주는 것까지는 확인 완료
- 아직 kakao cloud object storage로의 등록과, 자체 MySQL DB 등록은 미구현 상태

---

## 🔗 관련 이슈
- closes #49 

---

## 💡 추가 사항
1. Presigned Image를 Object Storage에 업로드하는 이슈는 차후 새롭게 등록될 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 파티 생성 폼에서 연령대 선택이 단일 선택에서 다중 선택으로 변경되었습니다.
  - 이미지 업로드 시 여러 이미지를 한 번에 선택 및 제출할 수 있습니다.

- **버그 수정**
  - 이미지 업로드 용량 제한 안내 문구가 5MB에서 10MB로 올바르게 수정되었습니다.

- **리팩터링**
  - 폼 필드 및 상태 변수명이 더 명확하도록 변경되었습니다.
  - 이미지 업로드 방식이 즉시 업로드에서 제출 시 일괄 업로드로 변경되었습니다.

- **기타**
  - 욕설 필터링 기능이 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->