### PR TITLE
Cs 310 feat/직관일지 작성 및 조회 api 연결

### DIFF
--- a/src/pages/InitialProfile/SetProfile.js
+++ b/src/pages/InitialProfile/SetProfile.js
@@ -12,7 +12,12 @@ const SetProfile = () => {
     const [showModal, setShowModal] = useState(false);
     const navigate = useNavigate();
     const location = useLocation();
-    const [selectedTeam, setSelectedTeam] = useState(location.state?.selectedTeam || '');
+    const [selectedTeam, setSelectedTeam] = useState(() => {
+        const fromState = location.state?.selectedTeam;
+        if (fromState) return fromState;
+        const fromStorage = localStorage.getItem('selectedTeam');
+        return fromStorage ? Number(fromStorage) : '';
+    });
 
     // Profile image crop state
     const [profileImage, setProfileImage] = useState(null);
@@ -43,9 +48,38 @@ const SetProfile = () => {
             return;
         }
 
+        let thumbnailURL = 'default.png';
+
+        // 이미지가 있다면 presigned URL 요청 및 업로드 수행
+        if (profileImage) {
+            try {
+                const file = await fetch(profileImage).then(res => res.blob());
+
+                const fileName = `${Date.now()}.png`; // 또는 uuid 등 유니크한 이름
+                const presignedRes = await axios.post(
+                    `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/presigned-url`,
+                    { fileName },
+                    { headers: { 'Content-Type': 'application/json' }, withCredentials: true }
+                );
+
+                await fetch(presignedRes.data.presignedUrl, {
+                    method: 'PUT',
+                    body: file,
+                    headers: { 'Content-Type': 'image/png' },
+                });
+
+                thumbnailURL = presignedRes.data.accessUrl; // 최종 접근 URL
+            } catch (err) {
+                console.error("이미지 업로드 실패:", err);
+                setShowModal(true);
+                return;
+            }
+        }
+
         const payload = {
             nickname,
             teamId: Number(selectedTeam),
+            thumbnailURL
         };
 
         try {
@@ -53,19 +87,13 @@ const SetProfile = () => {
                 `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/register`,
                 payload,
                 {
-                    headers: {
-                        'Content-Type': 'application/json',
-                    },
+                    headers: { 'Content-Type': 'application/json' },
                     withCredentials: true,
                 }
             );
-
-            console.log("✅ 요청 성공:", response.data);
-            console.log("📤 보낸 데이터:", payload);
             navigate('/login-complete');
         } catch (error) {
             console.error("❌ 요청 실패:", error.response ? error.response.data : error.message);
-            console.log("📤 보낸 데이터:", payload);
             setShowModal(true);
         }
     };

--- a/src/pages/LiveMatchDiary/DiaryDetail.js
+++ b/src/pages/LiveMatchDiary/DiaryDetail.js
@@ -1,30 +1,46 @@
 // 직관일지 상세 페이지
-import React, {useState} from 'react';
+import React, {useState, useEffect} from 'react';
 import {useNavigate, useParams} from 'react-router-dom';
-import dummyDiaries from '../../components/DummyData/dummyDiaries';
 import styles from './DiaryDetail.module.css';
 import TabNav from "../../components/TabNav/TabNav";
 import Modal from "../../components/Modal/Modal";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import axios from 'axios';
 
 const DiaryDetail = () => {
     const {id} = useParams();
-    const stored = JSON.parse(localStorage.getItem('customDiaries')) || [];
-    const allDiaries = [...stored, ...dummyDiaries];
-    const diary = allDiaries.find((entry) => entry.id === Number(id));
+    const [diary, setDiary] = useState(null);
+    const [loading, setLoading] = useState(true);
     const [showMenu, setShowMenu] = useState(false);
     const [showModal, setShowModal] = useState(false);
     const [showCasterbot, setShowCasterbot] = useState(false);
 
-
     const navigate = useNavigate();
     const tabLabels = ["나의 직관일지"];
-  
+
     function handleBack() {
         navigate('/diary/list');
     }
 
+    useEffect(() => {
+        const fetchDiary = async () => {
+            try {
+                const response = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${id}`, {
+                    withCredentials: true,
+                });
+                setDiary(response.data);
+            } catch (error) {
+                console.error('일지 불러오기 실패:', error);
+                setDiary(null);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchDiary();
+    }, [id]);
+
+    if (loading) return <div>로딩 중...</div>;
     if (!diary) return <div>일지를 찾을 수 없습니다.</div>;
 
     return (
@@ -70,11 +86,9 @@ const DiaryDetail = () => {
                     </div>
                 </div>
 
-                {diary.image && (
-                    <div className={styles.imageWrapper}>
-                        <img src={diary.image} alt="diary" className={styles.image}/>
-                    </div>
-                )}
+                <div className={styles.imageWrapper}>
+                    <img src={diary.image || '/default.png'} alt="diary" className={styles.image}/>
+                </div>
 
                 <div className={styles.content}>
                     {diary.content}
@@ -89,9 +103,6 @@ const DiaryDetail = () => {
                             {
                                 label: '확인',
                                 onClick: () => {
-                                    const stored = JSON.parse(localStorage.getItem('customDiaries')) || [];
-                                    const updated = stored.filter((entry) => entry.id !== diary.id);
-                                    localStorage.setItem('customDiaries', JSON.stringify(updated));
                                     setShowModal(false);
                                     navigate('/diary/list');
                                 }

--- a/src/pages/LiveMatchDiary/DiaryDetail.js
+++ b/src/pages/LiveMatchDiary/DiaryDetail.js
@@ -67,7 +67,16 @@ const DiaryDetail = () => {
                                 <div
                                     className={styles.menuItem}
                                     onClick={() => {
-                                        navigate(`/diary/newdiary`, {state: diary});
+                                        navigate(`/diary/newdiary`, {
+                                            state: {
+                                                id: diary.postId,          // ✅ 이걸 명시적으로 넣어줘야 NewDiary.js에서 인식 가능
+                                                team: diary.team,
+                                                title: diary.title,
+                                                content: diary.content,
+                                                image: diary.image,
+                                                twpDate: diary.date
+                                            }
+                                        });
                                     }}
                                 >
                                     수정하기

--- a/src/pages/LiveMatchDiary/DiaryDetail.js
+++ b/src/pages/LiveMatchDiary/DiaryDetail.js
@@ -96,7 +96,7 @@ const DiaryDetail = () => {
                 </div>
 
                 <div className={styles.imageWrapper}>
-                    <img src={diary.image || '/default.png'} alt="diary" className={styles.image}/>
+                    <img src={diary.image || `${process.env.PUBLIC_URL}/exImage.png`} alt="diary" className={styles.image}/>
                 </div>
 
                 <div className={styles.content}>

--- a/src/pages/LiveMatchDiary/DiaryDetail.module.css
+++ b/src/pages/LiveMatchDiary/DiaryDetail.module.css
@@ -57,6 +57,7 @@
 .menuPopup {
     position: absolute;
     top: 1.5rem;
+    min-width: 5.5rem;
     right: 0;
     background: #e4e4e4;
     border-radius: 4px;
@@ -66,6 +67,8 @@
 
 .menuItem {
     padding: 0.3rem 0.8rem;
+    display: flex;
+    justify-content: center;
     cursor: pointer;
 }
 

--- a/src/pages/LiveMatchDiary/DiaryList.js
+++ b/src/pages/LiveMatchDiary/DiaryList.js
@@ -7,7 +7,7 @@ import TabNav from "../../components/TabNav/TabNav";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import axios from 'axios';
-import {teamInfoMap} from "../../utils/teamInfoMap";
+import {teamInfoMap, teamInfoMapCommunity} from "../../utils/teamInfoMap";
 
 
 const DiaryList = () => {
@@ -20,9 +20,13 @@ const DiaryList = () => {
     const tabLabels = ["나의 직관일지"];
     const [showCasterbot, setShowCasterbot] = useState(false);
 
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
 
     useEffect(() => {
         const fetchMyDiaries = async () => {
+            setLoading(true);
+            setError(null);
             try {
                 const response = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/my`, {
                     params: {
@@ -33,7 +37,7 @@ const DiaryList = () => {
                 });
 
                 const data = response.data.map((entry) => {
-                    const teamData = teamInfoMap.find(team => team.teamId === entry.TeamName);
+                    const teamData = teamInfoMapCommunity.find(team => team.teamId === entry.TeamName);
                     return {
                         id: entry.postId,
                         title: entry.title,
@@ -41,7 +45,7 @@ const DiaryList = () => {
                         image: entry.thumbnail || null,
                         // image: `${process.env.PUBLIC_URL}/exImage.png` || null, // 임시 이미지
                         team: teamData?.name || '',
-                        teamLogo: teamData?.logo || '/Logo/TeamLogo/default_logo.png',
+                        teamLogo: teamData?.logo  || `${process.env.PUBLIC_URL}/exImage.png`,
                         content: '',
                     };
                 });
@@ -49,6 +53,9 @@ const DiaryList = () => {
 
             } catch (error) {
                 console.error('직관일지 목록 불러오기 실패:', error);
+                setError('직관일지를 불러오는 중 오류가 발생했습니다.');
+            } finally {
+                setLoading(false);
             }
         };
 
@@ -87,7 +94,7 @@ const DiaryList = () => {
                             style={{cursor: 'pointer'}}
                         >
                             {entry.image ? (
-                                <img src={entry.image} alt="thumbnail" className={styles.thumbnail}/>
+                                <img src={entry.image || `${process.env.PUBLIC_URL}/exImage.png` } alt="thumbnail" className={styles.thumbnail}/>
                             ) : null}
                             <div className={styles.entryContent}>
                                 <span className={styles.entryTitle}>{entry.title}</span>

--- a/src/pages/LiveMatchDiary/DiaryList.js
+++ b/src/pages/LiveMatchDiary/DiaryList.js
@@ -3,10 +3,23 @@ import React, {useEffect, useState} from 'react';
 import {useNavigate, useSearchParams} from 'react-router-dom';
 import Pagination from '@mui/material/Pagination';
 import styles from './DiaryList.module.css';
-import dummyDiaries from '../../components/DummyData/dummyDiaries';
 import TabNav from "../../components/TabNav/TabNav";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import axios from 'axios';
+
+const teamInfoMap = [
+    {id: 1, teamId: 'NC_DINOS', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
+    {id: 2, teamId: 'SAMSUNG_LIONS', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
+    {id: 3, teamId: 'DOOSAN_BEARS', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
+    {id: 4, teamId: 'HANWHA_EAGLES', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
+    {id: 5, teamId: 'KIA_TIGERS', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
+    {id: 6, teamId: 'KT_WIZ', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
+    {id: 7, teamId: 'LOTTE_GIANTS', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
+    {id: 8, teamId: 'LG_TWINS', name: 'LG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`},
+    {id: 9, teamId: 'SSG_LANDERS', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
+    {id: 10, teamId: 'KIWOOM_HEROES', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
+];
 
 const DiaryList = () => {
     const [searchParams, setSearchParams] = useSearchParams();
@@ -20,10 +33,39 @@ const DiaryList = () => {
 
 
     useEffect(() => {
-        //setDiaries(dummyDiaries);
-        const customDiaries = JSON.parse(localStorage.getItem('customDiaries')) || [];
-        setDiaries([...customDiaries, ...dummyDiaries]);
-    }, []);
+        const fetchMyDiaries = async () => {
+            try {
+                const response = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/my`, {
+                    params: {
+                        page: page - 1,
+                        size: PER_PAGE,
+                    },
+                    withCredentials: true, // 필요시 쿠키 인증
+                });
+
+                const data = response.data.map((entry) => {
+                    const teamData = teamInfoMap.find(team => team.teamId === entry.TeamName);
+                    return {
+                        id: entry.postId,
+                        title: entry.title,
+                        date: entry.twpDate || entry.date,
+                        image: entry.thumbnail || null,
+                        // image: `${process.env.PUBLIC_URL}/exImage.png` || null, // 임시 이미지
+                        team: teamData?.name || '',
+                        teamLogo: teamData?.logo || '/Logo/TeamLogo/default_logo.png',
+                        content: '',
+                    };
+                });
+                setDiaries(data);
+
+            } catch (error) {
+                console.error('직관일지 목록 불러오기 실패:', error);
+            }
+        };
+
+        fetchMyDiaries();
+        // setDiaries([...customDiaries, ...dummyDiaries]);
+    }, [page]);
 
     const handlePageChange = (_, value) => {
         setSearchParams({page: value});
@@ -46,16 +88,18 @@ const DiaryList = () => {
                 {/*<h2 className={styles.title}>나의 직관일지</h2>*/}
                 <TabNav tabs={tabLabels} onBack={handleBack}/>
                 <div className={styles.entryBox}>
-                    {pagedDiaries.map((entry) => (
+                    {pagedDiaries.length === 0 ? (
+                        <div className={styles.emptyMessage}>아직 작성한 직관일지가 없어요!</div>
+                    ) : pagedDiaries.map((entry) => (
                         <div
                             key={entry.id}
                             className={styles.entry}
                             onClick={() => handleClickDiary(entry.id)}
                             style={{cursor: 'pointer'}}
                         >
-                            {entry.image && (
+                            {entry.image ? (
                                 <img src={entry.image} alt="thumbnail" className={styles.thumbnail}/>
-                            )}
+                            ) : null}
                             <div className={styles.entryContent}>
                                 <span className={styles.entryTitle}>{entry.title}</span>
                                 <span className={styles.entryDate}>{entry.date}</span>
@@ -63,35 +107,35 @@ const DiaryList = () => {
                             </div>
                         </div>
                     ))}
-                    <div className={styles.paginationWrapper}>
-                        <Pagination
-                            count={Math.ceil(diaries.length / PER_PAGE)}
-                            page={page}
-                            onChange={handlePageChange}
-                            variant="outlined"
-                            shape="rounded"
-                            sx={{
-                                '& .MuiPaginationItem-root': {
-                                    color: '#784af4',
-                                    border: '1px solid #784af4',
-                                    cursor: 'pointer',
-                                },
-                                '& .Mui-selected': {
-                                    backgroundColor: '#784af4',
-                                    color: '#fff',
-                                    borderColor: '#784af4',
-                                },
-                                '& .MuiPaginationItem-ellipsis': {
-                                    border: 'none',
-                                    color: '#784af4',
-                                    backgroundColor: 'transparent',
-                                },
-                            }}
-                        />
-                    </div>
+                </div>
+                <div className={styles.paginationWrapper}>
+                    <Pagination
+                        count={Math.ceil(diaries.length / PER_PAGE)}
+                        page={page}
+                        onChange={handlePageChange}
+                        variant="outlined"
+                        shape="rounded"
+                        sx={{
+                            '& .MuiPaginationItem-root': {
+                                color: '#784af4',
+                                border: '1px solid #784af4',
+                                cursor: 'pointer',
+                            },
+                            '& .Mui-selected': {
+                                backgroundColor: '#784af4',
+                                color: '#fff',
+                                borderColor: '#784af4',
+                            },
+                            '& .MuiPaginationItem-ellipsis': {
+                                border: 'none',
+                                color: '#784af4',
+                                backgroundColor: 'transparent',
+                            },
+                        }}
+                    />
                 </div>
             </div>
-            <CasterbotButton onClick={() => setShowCasterbot(true)} />
+            <CasterbotButton onClick={() => setShowCasterbot(true)}/>
 
             {showCasterbot && (
                 <CasterbotModal onClose={() => setShowCasterbot(false)}/>

--- a/src/pages/LiveMatchDiary/DiaryList.js
+++ b/src/pages/LiveMatchDiary/DiaryList.js
@@ -7,19 +7,8 @@ import TabNav from "../../components/TabNav/TabNav";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import axios from 'axios';
+import {teamInfoMap} from "../../utils/teamInfoMap";
 
-const teamInfoMap = [
-    {id: 1, teamId: 'NC_DINOS', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
-    {id: 2, teamId: 'SAMSUNG_LIONS', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
-    {id: 3, teamId: 'DOOSAN_BEARS', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
-    {id: 4, teamId: 'HANWHA_EAGLES', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
-    {id: 5, teamId: 'KIA_TIGERS', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
-    {id: 6, teamId: 'KT_WIZ', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
-    {id: 7, teamId: 'LOTTE_GIANTS', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
-    {id: 8, teamId: 'LG_TWINS', name: 'LG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`},
-    {id: 9, teamId: 'SSG_LANDERS', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
-    {id: 10, teamId: 'KIWOOM_HEROES', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
-];
 
 const DiaryList = () => {
     const [searchParams, setSearchParams] = useSearchParams();

--- a/src/pages/LiveMatchDiary/DiaryList.module.css
+++ b/src/pages/LiveMatchDiary/DiaryList.module.css
@@ -54,7 +54,7 @@
 }
 
 .teamLogo {
-  width: 20px;
+  width: 40px;
   margin-top: 4px;
 }
 
@@ -81,4 +81,11 @@
 .casterbotButton img {
     width: 100%;
     height: 100%;
+}
+
+.emptyMessage {
+    text-align: center;
+    font-size: 1.2rem;
+    color: #888;
+    margin: 2rem 0;
 }

--- a/src/pages/LiveMatchDiary/NewDiary.js
+++ b/src/pages/LiveMatchDiary/NewDiary.js
@@ -1,5 +1,6 @@
 // 직관일지 작성 페이지
 import React, {useEffect, useState} from 'react';
+import Modal from '../../components/Modal/Modal';
 import {useLocation, useNavigate} from 'react-router-dom';
 import styles from './NewDiary.module.css';
 import CasterbotModal from "../Chatbot/CasterbotModal";
@@ -49,6 +50,10 @@ const NewDiary = () => {
     const [objectUrl, setObjectUrl] = useState(null);
     const [showCasterbot, setShowCasterbot] = useState(false);
 
+    const [showModal, setShowModal] = useState(false);
+    const [modalTitle, setModalTitle] = useState('');
+    const [modalMessage, setModalMessage] = useState('');
+
 
     useEffect(() => {
         return () => {
@@ -77,7 +82,7 @@ const NewDiary = () => {
         const postData = {
             title,
             content,
-            image: image || null,
+            image: imageFile,
             twpDate: isEditing ? location.state?.twpDate : new Date().toISOString().split('T')[0],
             isSecret: true
         };
@@ -94,10 +99,14 @@ const NewDiary = () => {
                     withCredentials: true
                 });
             }
-            navigate('/diary/list');
+            setModalTitle('알림');
+            setModalMessage(isEditing ? '직관일지가 성공적으로 수정되었습니다!' : '직관일지가 성공적으로 작성되었습니다!');
+            setShowModal(true);
         } catch (error) {
             console.error('직관일지 등록 실패:', error);
-            alert('직관일지 등록 중 오류가 발생했습니다.');
+            setModalTitle('오류');
+            setModalMessage('직관일지 등록 중 오류가 발생했습니다.');
+            setShowModal(true);
         }
     };
 
@@ -178,6 +187,21 @@ const NewDiary = () => {
 
             {showCasterbot && (
                 <CasterbotModal onClose={() => setShowCasterbot(false)}/>
+            )}
+            {showModal && (
+                <Modal
+                    title={modalTitle}
+                    message={modalMessage}
+                    buttons={[
+                        {
+                            label: '확인',
+                            onClick: () => {
+                                setShowModal(false);
+                                navigate('/diary/list');
+                            }
+                        }
+                    ]}
+                />
             )}
         </>
     );

--- a/src/pages/LiveMatchDiary/NewDiary.js
+++ b/src/pages/LiveMatchDiary/NewDiary.js
@@ -11,18 +11,18 @@ const teams = [
     '삼성 라이온즈', 'SSG 랜더스', 'NC 다이노스', '키움 히어로즈', 'KT 위즈'
 ];
 
-const teamLogos = {
-    '한화 이글스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`,
-    '기아 타이거즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`,
-    '두산 베어스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`,
-    'LG 트윈스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`,
-    '롯데 자이언츠': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`,
-    '삼성 라이온즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`,
-    'SSG 랜더스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`,
-    'NC 다이노스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`,
-    '키움 히어로즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`,
-    'KT 위즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`
-};
+// const teamLogos = {
+//     '한화 이글스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`,
+//     '기아 타이거즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`,
+//     '두산 베어스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`,
+//     'LG 트윈스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`,
+//     '롯데 자이언츠': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`,
+//     '삼성 라이온즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`,
+//     'SSG 랜더스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`,
+//     'NC 다이노스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`,
+//     '키움 히어로즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`,
+//     'KT 위즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`
+// };
 
 const teamMap = {
     '한화 이글스': 'HANHWA_EAGLES',

--- a/src/pages/LiveMatchDiary/NewDiary.js
+++ b/src/pages/LiveMatchDiary/NewDiary.js
@@ -6,37 +6,9 @@ import styles from './NewDiary.module.css';
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import axios from 'axios';
+import {kbo_teams, teamMap} from "../../utils/teamInfoMap";
 
-const teams = [
-    '한화 이글스', '기아 타이거즈', '두산 베어스', 'LG 트윈스', '롯데 자이언츠',
-    '삼성 라이온즈', 'SSG 랜더스', 'NC 다이노스', '키움 히어로즈', 'KT 위즈'
-];
 
-// const teamLogos = {
-//     '한화 이글스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`,
-//     '기아 타이거즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`,
-//     '두산 베어스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`,
-//     'LG 트윈스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`,
-//     '롯데 자이언츠': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`,
-//     '삼성 라이온즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`,
-//     'SSG 랜더스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`,
-//     'NC 다이노스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`,
-//     '키움 히어로즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`,
-//     'KT 위즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`
-// };
-
-const teamMap = {
-    '한화 이글스': 'HANHWA_EAGLES',
-    '기아 타이거즈': 'KIA_TIGERS',
-    '두산 베어스': 'DOOSAN_BEARS',
-    'LG 트윈스': 'LG_TWINS',
-    '롯데 자이언츠': 'LOTTE_GIANTS',
-    '삼성 라이온즈': 'SAMSUNG_LIONS',
-    'SSG 랜더스': 'SSG_LANDERS',
-    'NC 다이노스': 'NC_DINOS',
-    '키움 히어로즈': 'KIWOOM_HEROES',
-    'KT 위즈': 'KT_WIZ'
-};
 
 const NewDiary = () => {
     const navigate = useNavigate();
@@ -141,7 +113,7 @@ const NewDiary = () => {
                             required
                         >
                             <option value="" disabled>팀을 선택해주세요</option>
-                            {teams.map((t, i) => (
+                            {kbo_teams.map((t, i) => (
                                 <option key={i} value={t}>{t}</option>
                             ))}
                         </select>

--- a/src/pages/LiveMatchDiary/NewDiary.js
+++ b/src/pages/LiveMatchDiary/NewDiary.js
@@ -4,6 +4,7 @@ import {useLocation, useNavigate} from 'react-router-dom';
 import styles from './NewDiary.module.css';
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
+import axios from 'axios';
 
 const teams = [
     '한화 이글스', '기아 타이거즈', '두산 베어스', 'LG 트윈스', '롯데 자이언츠',
@@ -21,6 +22,19 @@ const teamLogos = {
     'NC 다이노스': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`,
     '키움 히어로즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`,
     'KT 위즈': `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`
+};
+
+const teamMap = {
+    '한화 이글스': 'HANHWA_EAGLES',
+    '기아 타이거즈': 'KIA_TIGERS',
+    '두산 베어스': 'DOOSAN_BEARS',
+    'LG 트윈스': 'LG_TWINS',
+    '롯데 자이언츠': 'LOTTE_GIANTS',
+    '삼성 라이온즈': 'SAMSUNG_LIONS',
+    'SSG 랜더스': 'SSG_LANDERS',
+    'NC 다이노스': 'NC_DINOS',
+    '키움 히어로즈': 'KIWOOM_HEROES',
+    'KT 위즈': 'KT_WIZ'
 };
 
 const NewDiary = () => {
@@ -57,36 +71,34 @@ const NewDiary = () => {
         }
     };
 
-    // const handleSubmit = (e) => {
-    //     e.preventDefault();
-    //     // TODO: DB에 만든 직관일지 데이터 보내는 로직 구현
-    //     console.log({team, title, content, imageFile});
-    //
-    // };
-
-    const handleSubmit = (e) => {
+    const handleSubmit = async (e) => {
         e.preventDefault();
 
-        const diaryData = {
-            id: isEditing ? location.state.id : Date.now(),
-            team,
+        const postData = {
             title,
             content,
-            date: isEditing ? location.state.date : new Date().toISOString().slice(0, 10).replace(/-/g, '.'),
-            image: image ? image : null,
-            teamLogo: teamLogos[team] || null
+            image: image || null,
+            twpDate: isEditing ? location.state?.twpDate : new Date().toISOString().split('T')[0],
+            isSecret: true
         };
 
-        const existing = JSON.parse(localStorage.getItem('customDiaries')) || [];
-
-        if (isEditing) {
-            const updated = existing.map(d => d.id === diaryData.id ? diaryData : d);
-            localStorage.setItem('customDiaries', JSON.stringify(updated));
-        } else {
-            localStorage.setItem('customDiaries', JSON.stringify([...existing, diaryData]));
+        try {
+            const teamTag = teamMap[team];
+            if (isEditing) {
+                const postId = location.state?.id;
+                await axios.patch(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${teamTag}/${postId}`, postData, {
+                    withCredentials: true
+                });
+            } else {
+                await axios.post(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${teamTag}`, postData, {
+                    withCredentials: true
+                });
+            }
+            navigate('/diary/list');
+        } catch (error) {
+            console.error('직관일지 등록 실패:', error);
+            alert('직관일지 등록 중 오류가 발생했습니다.');
         }
-
-        navigate('/diary/list');
     };
 
     const handleCancel = () => {

--- a/src/pages/Main/MainPage.js
+++ b/src/pages/Main/MainPage.js
@@ -6,19 +6,7 @@ import CasterbotModal from "../Chatbot/CasterbotModal";
 import TeamTabNav from "../../components/TeamTabNav/TeamTabNav";
 import ScheduleSection from "./ScheduleSection";
 import DummyMatchData from "../../components/DummyData/DummyMatchData";
-
-const teamInfoMap = [
-    {id: 1, teamId: 'NC Dinos', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
-    {id: 2, teamId: 'Samsung Lions', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
-    {id: 3, teamId: 'Doosan Bears', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
-    {id: 4, teamId: 'Hanhwa Eagles', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
-    {id: 5, teamId: 'Kia Tigers', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
-    {id: 6, teamId: 'KT Wiz', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
-    {id: 7, teamId: 'Lotte Giants', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
-    {id: 8, teamId: 'LG Twins', name: 'LG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`},
-    {id: 9, teamId: 'SSG Landers', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
-    {id: 10, teamId: 'Kiwoom Heroes', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
-];
+import {teamInfoMap} from "../../utils/teamInfoMap";
 
 export default function MainPage() {
     const [showCasterbot, setShowCasterbot] = useState(false);

--- a/src/utils/teamInfoMap.js
+++ b/src/utils/teamInfoMap.js
@@ -23,3 +23,21 @@ export const teamInfoMapCommunity = [
     {id: 9, teamId: 'SSG_LANDERS', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
     {id: 10, teamId: 'KIWOOM_HEROES', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
 ];
+
+export const teamMap = {
+    '한화 이글스': 'HANHWA_EAGLES',
+    '기아 타이거즈': 'KIA_TIGERS',
+    '두산 베어스': 'DOOSAN_BEARS',
+    'LG 트윈스': 'LG_TWINS',
+    '롯데 자이언츠': 'LOTTE_GIANTS',
+    '삼성 라이온즈': 'SAMSUNG_LIONS',
+    'SSG 랜더스': 'SSG_LANDERS',
+    'NC 다이노스': 'NC_DINOS',
+    '키움 히어로즈': 'KIWOOM_HEROES',
+    'KT 위즈': 'KT_WIZ'
+};
+
+export const kbo_teams = [
+    '한화 이글스', '기아 타이거즈', '두산 베어스', 'LG 트윈스', '롯데 자이언츠',
+    '삼성 라이온즈', 'SSG 랜더스', 'NC 다이노스', '키움 히어로즈', 'KT 위즈'
+];

--- a/src/utils/teamInfoMap.js
+++ b/src/utils/teamInfoMap.js
@@ -1,0 +1,12 @@
+export const teamInfoMap = [
+    {id: 1, teamId: 'NC Dinos', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
+    {id: 2, teamId: 'Samsung Lions', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
+    {id: 3, teamId: 'Doosan Bears', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
+    {id: 4, teamId: 'Hanhwa Eagles', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
+    {id: 5, teamId: 'Kia Tigers', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
+    {id: 6, teamId: 'KT Wiz', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
+    {id: 7, teamId: 'Lotte Giants', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
+    {id: 8, teamId: 'LG Twins', name: 'LG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`},
+    {id: 9, teamId: 'SSG Landers', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
+    {id: 10, teamId: 'Kiwoom Heroes', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
+];

--- a/src/utils/teamInfoMap.js
+++ b/src/utils/teamInfoMap.js
@@ -10,3 +10,16 @@ export const teamInfoMap = [
     {id: 9, teamId: 'SSG Landers', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
     {id: 10, teamId: 'Kiwoom Heroes', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
 ];
+
+export const teamInfoMapCommunity = [
+    {id: 1, teamId: 'NC_DINOS', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
+    {id: 2, teamId: 'Samsung_LIONS', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
+    {id: 3, teamId: 'DOOSAN_BEARS', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
+    {id: 4, teamId: 'HANHWA_EAGLES', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
+    {id: 5, teamId: 'KIA_TIGERS', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
+    {id: 6, teamId: 'KT_WIZ', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
+    {id: 7, teamId: 'LOTTE_GIANTS', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
+    {id: 8, teamId: 'LG_TWINS', name: 'LG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`},
+    {id: 9, teamId: 'SSG_LANDERS', name: 'SSG', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
+    {id: 10, teamId: 'KIWOOM_HEROES', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
+];


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 직관일지 목록 조회 API 연결
- 해당 직관일지 이미지가 없는 경우 아무런 이미지도 표시되지 않음

### 2. 직관일지 상세 조회 API 연결

### 3. 직관일지 작성 API 연결
- 현재 cdc 수정 이슈로 인해 mongoDB에는 작성한 직관일지가 올라가지 않음

---

## 🔗 관련 이슈
- closes #56 

---

## 💡 추가 사항
- PR 완료 후 직관일지 수정 API 및 삭제 API 연결 예정입니다.
- mongoDB 데이터 수정은 차후 CDC 이슈 해결 완료 이후 반영될 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 프로필 이미지 업로드 기능이 추가되어, 프로필 생성 시 이미지를 선택하면 서버에 업로드됩니다.
  - 일기장 목록, 상세, 작성/수정이 더 이상 로컬 데이터가 아닌 백엔드 서버와 연동되어 실제 데이터를 불러오고 저장합니다.
  - 팀 선택 드롭다운이 한국 프로야구팀 목록으로 업데이트되었습니다.

- **버그 수정**
  - 일기장 상세 페이지에서 이미지가 없을 경우 기본 이미지를 표시하도록 개선되었습니다.
  - 일기장 삭제 시 불필요한 로컬 데이터 업데이트를 제거하였습니다.

- **스타일**
  - 일기장 메뉴 팝업의 최소 너비가 늘어나고, 메뉴 항목이 중앙 정렬됩니다.
  - 팀 로고 크기가 두 배로 커졌으며, 일기장 목록이 비어있을 때 안내 메시지의 스타일이 개선되었습니다.

- **리팩터**
  - 더미 데이터 및 localStorage 기반 데이터 처리 로직이 제거되고, axios를 통한 API 연동 방식으로 변경되었습니다.
  - 팀 정보 데이터가 외부 유틸 모듈로 분리되어 관리됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->