### PR TITLE
Cs 311 feat/직관일지 수정 및 삭제 api 연결

### DIFF
--- a/src/pages/InitialProfile/TeamChoice.js
+++ b/src/pages/InitialProfile/TeamChoice.js
@@ -47,7 +47,7 @@ const TeamChoice = () => {
                         {id: 1, teamId: 'NC Dinos', name: 'NC', logo: 'emblem_NC.png'},
                         {id: 2, teamId: 'Samsung Lions', name: '삼성', logo: 'emblem_SS.png'},
                         {id: 3, teamId: 'Doosan Bears', name: '두산', logo: 'emblem_OB.png'},
-                        {id: 4, teamId: 'Hanhwa Eagles', name: '한화', logo: 'emblem_HH.png'},
+                        {id: 4, teamId: 'Hanwha Eagles', name: '한화', logo: 'emblem_HH.png'},
                         {id: 5, teamId: 'Kia Tigers', name: 'KIA', logo: 'emblem_HT.png'},
                         {id: 6, teamId: 'KT Wiz', name: 'KT', logo: 'emblem_KT.png'},
                         {id: 7, teamId: 'Lotte Giants', name: '롯데', logo: 'emblem_LT.png'},

--- a/src/pages/LiveMatchDiary/DiaryDetail.js
+++ b/src/pages/LiveMatchDiary/DiaryDetail.js
@@ -115,8 +115,7 @@ const DiaryDetail = () => {
                                 label: '확인',
                                 onClick: async () => {
                                     try {
-                                        const tag = getTeamTagFromKoreanName(diary.team);
-                                        await axios.delete(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${tag}/${id}`, {
+                                        await axios.delete(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${id}`, {
                                             withCredentials: true
                                         });
                                         setShowModal(false);

--- a/src/pages/LiveMatchDiary/DiaryDetail.js
+++ b/src/pages/LiveMatchDiary/DiaryDetail.js
@@ -7,9 +7,10 @@ import Modal from "../../components/Modal/Modal";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import axios from 'axios';
+import { getTeamTagFromKoreanName } from "../../utils/teamInfoMap";
 
 const DiaryDetail = () => {
-    const {id} = useParams();
+    const {tag, id} = useParams();
     const [diary, setDiary] = useState(null);
     const [loading, setLoading] = useState(true);
     const [showMenu, setShowMenu] = useState(false);
@@ -26,7 +27,7 @@ const DiaryDetail = () => {
     useEffect(() => {
         const fetchDiary = async () => {
             try {
-                const response = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${id}`, {
+                const response = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${tag}/${id}`, {
                     withCredentials: true,
                 });
                 setDiary(response.data);
@@ -38,7 +39,7 @@ const DiaryDetail = () => {
             }
         };
         fetchDiary();
-    }, [id]);
+    }, [tag, id]);
 
     if (loading) return <div>로딩 중...</div>;
     if (!diary) return <div>일지를 찾을 수 없습니다.</div>;
@@ -71,6 +72,7 @@ const DiaryDetail = () => {
                                             state: {
                                                 id: diary.postId,          // ✅ 이걸 명시적으로 넣어줘야 NewDiary.js에서 인식 가능
                                                 team: diary.team,
+                                                tag: tag,
                                                 title: diary.title,
                                                 content: diary.content,
                                                 image: diary.image,
@@ -111,9 +113,19 @@ const DiaryDetail = () => {
                             {label: '취소', onClick: () => setShowModal(false)},
                             {
                                 label: '확인',
-                                onClick: () => {
-                                    setShowModal(false);
-                                    navigate('/diary/list');
+                                onClick: async () => {
+                                    try {
+                                        const tag = getTeamTagFromKoreanName(diary.team);
+                                        await axios.delete(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${tag}/${id}`, {
+                                            withCredentials: true
+                                        });
+                                        setShowModal(false);
+                                        navigate('/diary/list');
+                                    } catch (error) {
+                                        console.error('삭제 실패:', error);
+                                        setShowModal(false);
+                                        alert('삭제 중 오류가 발생했습니다.');
+                                    }
                                 }
                             }
                         ]}

--- a/src/pages/LiveMatchDiary/DiaryList.js
+++ b/src/pages/LiveMatchDiary/DiaryList.js
@@ -7,7 +7,8 @@ import TabNav from "../../components/TabNav/TabNav";
 import CasterbotModal from "../Chatbot/CasterbotModal";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import axios from 'axios';
-import {teamInfoMap, teamInfoMapCommunity} from "../../utils/teamInfoMap";
+import {teamInfoMapCommunity} from "../../utils/teamInfoMap";
+import Modal from "../../components/Modal/Modal";
 
 
 const DiaryList = () => {
@@ -22,6 +23,7 @@ const DiaryList = () => {
 
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState(null);
+    const [showModal, setShowModal] = useState(false);
 
     useEffect(() => {
         const fetchMyDiaries = async () => {
@@ -45,7 +47,7 @@ const DiaryList = () => {
                         image: entry.thumbnail || null,
                         // image: `${process.env.PUBLIC_URL}/exImage.png` || null, // 임시 이미지
                         team: teamData?.name || '',
-                        teamLogo: teamData?.logo  || `${process.env.PUBLIC_URL}/exImage.png`,
+                        teamLogo: teamData?.logo || `${process.env.PUBLIC_URL}/exImage.png`,
                         content: '',
                     };
                 });
@@ -76,6 +78,10 @@ const DiaryList = () => {
     // Navigate to diary detail page
     const handleClickDiary = (id) => {
         const clickedDiary = diaries.find(d => d.id === id);
+        if (!clickedDiary) {
+            setShowModal(true);
+            return;
+        }
         const teamTag = teamInfoMapCommunity.find(team => team.name === clickedDiary.team)?.teamId;
         if (teamTag) {
             navigate(`/diary/${teamTag}/${id}`);
@@ -98,7 +104,8 @@ const DiaryList = () => {
                             style={{cursor: 'pointer'}}
                         >
                             {entry.image ? (
-                                <img src={entry.image || `${process.env.PUBLIC_URL}/exImage.png` } alt="thumbnail" className={styles.thumbnail}/>
+                                <img src={entry.image || `${process.env.PUBLIC_URL}/exImage.png`} alt="thumbnail"
+                                     className={styles.thumbnail}/>
                             ) : null}
                             <div className={styles.entryContent}>
                                 <span className={styles.entryTitle}>{entry.title}</span>
@@ -139,6 +146,15 @@ const DiaryList = () => {
 
             {showCasterbot && (
                 <CasterbotModal onClose={() => setShowCasterbot(false)}/>
+            )}
+            {showModal && (
+                <Modal
+                    title="알림"
+                    message="직관일지를 찾을 수 없습니다!"
+                    buttons={[
+                        {label: '확인', onClick: () => setShowModal(false)},
+                    ]}
+                />
             )}
         </>
     );

--- a/src/pages/LiveMatchDiary/DiaryList.js
+++ b/src/pages/LiveMatchDiary/DiaryList.js
@@ -75,7 +75,11 @@ const DiaryList = () => {
 
     // Navigate to diary detail page
     const handleClickDiary = (id) => {
-        navigate(`/diary/${id}`);
+        const clickedDiary = diaries.find(d => d.id === id);
+        const teamTag = teamInfoMapCommunity.find(team => team.name === clickedDiary.team)?.teamId;
+        if (teamTag) {
+            navigate(`/diary/${teamTag}/${id}`);
+        }
     };
 
     return (

--- a/src/pages/LiveMatchDiary/NewDiary.js
+++ b/src/pages/LiveMatchDiary/NewDiary.js
@@ -13,8 +13,18 @@ import {kbo_teams, teamMap} from "../../utils/teamInfoMap";
 const NewDiary = () => {
     const navigate = useNavigate();
     const location = useLocation();
+    useEffect(() => {
+        console.log('🧭 location.state:', location.state);
+    }, []);
     const isEditing = !!location.state;
-    const [team, setTeam] = useState(location.state?.team || '');
+    const postId = isEditing ? location.state?.id : null;
+    // Enhanced team/tag initialization for editing mode
+    const teamTagFromState = location.state?.tag || null;
+    const teamNameFromTag = teamTagFromState
+        ? Object.entries(teamMap).find(([, tag]) => tag === teamTagFromState)?.[0]
+        : null;
+    const [team, setTeam] = useState(location.state?.team || teamNameFromTag || '');
+    const teamTag = team ? teamMap[team] : null;
     const [title, setTitle] = useState(location.state?.title || '');
     const [content, setContent] = useState(location.state?.content || '');
     const [image, setImage] = useState(location.state?.image || null);
@@ -60,9 +70,7 @@ const NewDiary = () => {
         };
 
         try {
-            const teamTag = teamMap[team];
-            if (isEditing) {
-                const postId = location.state?.id;
+            if (isEditing && postId && teamTag) {
                 await axios.patch(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${teamTag}/${postId}`, postData, {
                     withCredentials: true
                 });

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -112,7 +112,7 @@ function AppRouter() {
                     <Route index element={<NewDiary/>}/>
                 </Route>
                 {/* 직관일지 상세 */}
-                <Route path="/diary/:id" element={<MobileView/>}>
+                <Route path="/diary/:tag/:id" element={<MobileView/>}>
                     <Route index element={<DiaryDetail/>}/>
                 </Route>
             </Routes>

--- a/src/utils/teamInfoMap.js
+++ b/src/utils/teamInfoMap.js
@@ -24,6 +24,11 @@ export const teamInfoMapCommunity = [
     {id: 10, teamId: 'KIWOOM_HEROES', name: '키움', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`},
 ];
 
+export const getTeamTagFromKoreanName = (koreanName) => {
+    const team = teamInfoMapCommunity.find(t => koreanName.includes(t.name));
+    return team ? team.teamId : null;
+};
+
 export const teamMap = {
     '한화 이글스': 'HANHWA_EAGLES',
     '기아 타이거즈': 'KIA_TIGERS',

--- a/src/utils/teamInfoMap.js
+++ b/src/utils/teamInfoMap.js
@@ -2,7 +2,7 @@ export const teamInfoMap = [
     {id: 1, teamId: 'NC Dinos', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
     {id: 2, teamId: 'Samsung Lions', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
     {id: 3, teamId: 'Doosan Bears', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
-    {id: 4, teamId: 'Hanhwa Eagles', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
+    {id: 4, teamId: 'Hanwha Eagles', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
     {id: 5, teamId: 'Kia Tigers', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
     {id: 6, teamId: 'KT Wiz', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
     {id: 7, teamId: 'Lotte Giants', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
@@ -15,7 +15,7 @@ export const teamInfoMapCommunity = [
     {id: 1, teamId: 'NC_DINOS', name: 'NC', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
     {id: 2, teamId: 'Samsung_LIONS', name: '삼성', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
     {id: 3, teamId: 'DOOSAN_BEARS', name: '두산', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
-    {id: 4, teamId: 'HANHWA_EAGLES', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
+    {id: 4, teamId: 'HANWHA_EAGLES', name: '한화', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
     {id: 5, teamId: 'KIA_TIGERS', name: 'KIA', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
     {id: 6, teamId: 'KT_WIZ', name: 'KT', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
     {id: 7, teamId: 'LOTTE_GIANTS', name: '롯데', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
@@ -30,7 +30,7 @@ export const getTeamTagFromKoreanName = (koreanName) => {
 };
 
 export const teamMap = {
-    '한화 이글스': 'HANHWA_EAGLES',
+    '한화 이글스': 'HANWHA_EAGLES',
     '기아 타이거즈': 'KIA_TIGERS',
     '두산 베어스': 'DOOSAN_BEARS',
     'LG 트윈스': 'LG_TWINS',


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [x] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 직관일지 수정 API 연결
<img width="413" alt="image" src="https://github.com/user-attachments/assets/14627bf5-0b32-4b33-8167-ad19d8b2eaf3" />

- 직관일지에서 수정하기 버튼 클릭 시 해당 직관일지의 정보를 모두 가져오는 데 성공

### 2. 직관일지 삭제 API 연결
```
await axios.delete(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/${id}`, {
                                            withCredentials: true
                                        });
                                        를 통한 delete mapping 성공
```
- 현재 mongoDB CDC 오류 수정으로 인해 list에서는 삭제되지 않음

---

## 🔗 관련 이슈
- closes #58 

---

## 💡 추가 사항
- mongoDB CDC 수정 이후 재확인 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - "Hanhwa Eagles" 팀명을 "Hanwha Eagles"로 올바르게 수정했습니다.

- **신규 기능**
  - 팀 한글명을 기반으로 팀 태그를 반환하는 기능이 추가되었습니다.

- **기능 개선**
  - 라이브 매치 다이어리 상세 페이지 URL 구조에 팀 태그가 추가되어, 다이어리 접근 시 팀 정보를 명확히 확인할 수 있습니다.
  - 다이어리 목록에서 팀 정보가 포함된 상세 페이지로 이동하도록 개선되었으며, 존재하지 않는 다이어리 접근 시 경고 모달이 표시됩니다.
  - 다이어리 수정 시 팀 정보와 태그 초기화 및 검증 로직이 강화되었습니다.
  - 다이어리 삭제 시 오류 발생 시 안내 메시지가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->