### PR TITLE
Cs 361 feat/직관팟 알림 구현

### DIFF
--- a/src/components/Modal/NotificationModal/NotificationModal.js
+++ b/src/components/Modal/NotificationModal/NotificationModal.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from "react";
 import axios from "axios";
+import {formatNotificationDate} from "../../../utils/formatNotificationDate";
 import styles from "./NotificationModal.module.css";
 
 const tabs = ["전체", "직관팟", "커뮤니티"];
@@ -74,7 +75,7 @@ const NotificationModal = ({onClose}) => {
         try {
             const allNotifications = groupedNotifications["전체"];
             // Mark each notification as read via API
-            await Promise.all(
+            const results = await Promise.allSettled(
                 allNotifications.map((item) =>
                     axios.patch(
                         `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
@@ -83,6 +84,11 @@ const NotificationModal = ({onClose}) => {
                     )
                 )
             );
+            results.forEach((result, index) => {
+                if (result.status === 'rejected') {
+                    console.error(`알림 ${allNotifications[index].id} 읽기 처리 실패:`, result.reason);
+                }
+            });
             // After marking all as read, clear state so none remain
             setGroupedNotifications({
                 전체: [],
@@ -184,22 +190,7 @@ const NotificationModal = ({onClose}) => {
                                                 <strong>{item.title}</strong>
                                                 <div className={styles.subText}>{item.content}</div>
                                                 <div className={styles.timestamp}>
-                                                    {item.createdAt
-                                                        ? (() => {
-                                                            const dateObj = new Date(
-                                                                item.createdAt
-                                                                    .replace(/\./g, "-")
-                                                                    .replace(" ", "T")
-                                                            );
-                                                            return dateObj.toLocaleString("ko-KR", {
-                                                                year: "numeric",
-                                                                month: "numeric",
-                                                                day: "numeric",
-                                                                hour: "numeric",
-                                                                minute: "numeric"
-                                                            });
-                                                        })()
-                                                        : ""}
+                                                    {formatNotificationDate(item.createdAt)}
                                                 </div>
                                             </div>
                                             <div className={styles.actionButtons}>
@@ -222,22 +213,7 @@ const NotificationModal = ({onClose}) => {
                                             <strong>{item.title}</strong>
                                             <div className={styles.subText}>{item.content}</div>
                                             <div className={styles.timestamp}>
-                                                {item.createdAt
-                                                    ? (() => {
-                                                        const dateObj = new Date(
-                                                            item.createdAt
-                                                                .replace(/\./g, "-")
-                                                                .replace(" ", "T") + (item.createdAt.includes(":") ? ":00" : "")
-                                                        );
-                                                        return dateObj.toLocaleString("ko-KR", {
-                                                            year: "numeric",
-                                                            month: "numeric",
-                                                            day: "numeric",
-                                                            hour: "numeric",
-                                                            minute: "numeric"
-                                                        });
-                                                    })()
-                                                    : ""}
+                                                {formatNotificationDate(item.createdAt)}
                                             </div>
                                         </div>
                                     )}

--- a/src/components/Modal/NotificationModal/NotificationModal.js
+++ b/src/components/Modal/NotificationModal/NotificationModal.js
@@ -1,82 +1,127 @@
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
+import axios from "axios";
 import styles from "./NotificationModal.module.css";
 
 const tabs = ["전체", "직관팟", "커뮤니티"];
 
-const dummyData = {
-    전체: [
-        {
-            id: 1,
-            category: "직관팟",
-            type: "참가요청",
-            user: "Ashwin Bose",
-            date: "3/22(토)",
-            message: "한화 vs KT 개막전 직관 파티 참가를 요청했어요.",
-            content: "“안녕하세요! 저도 이 경기 같이 직관하고 싶어요!”",
-            new: true,
-            status: null
-        },
-        {
-            id: 2,
-            category: "직관팟",
-            type: "승인",
-            user: "ZSJ",
-            date: "3/27(토)",
-            message: "한화 vs 삼성 직관 함께보기 가 승인되었어요!",
-            content: "가입이 승인되었어요!",
-            new: false
-        },
-    ],
-    직관팟: [
-        {
-            id: 1,
-            category: "직관팟",
-            type: "참가요청",
-            user: "Ashwin Bose",
-            date: "3/22(토)",
-            message: "한화 vs KT 개막전 직관 파티 참가 요청",
-            content: "“안녕하세요! 저도 이 경기 같이 직관하고 싶어요!”",
-            new: true,
-            status: null
-        },
-        {
-            id: 2,
-            category: "직관팟",
-            type: "승인",
-            user: "ZSJ",
-            date: "3/27(토)",
-            message: "한화 vs 삼성 직관 함께보기 승인",
-            content: "가입이 승인되었어요!",
-            new: false
-        },
-    ],
-    커뮤니티: [],
+
+const TYPE_TO_TAB = {
+  COMMENT: "커뮤니티",
+  PARTY_REQUEST: "직관팟",
+  PARTY_JOINED: "직관팟",
+  PARTY_APPROVED: "직관팟",
+  PARTY_REFUSED: "직관팟",
 };
 
 const NotificationModal = ({onClose}) => {
+    const [groupedNotifications, setGroupedNotifications] = useState({
+      전체: [],
+      직관팟: [],
+      커뮤니티: [],
+    });
     const [activeTab, setActiveTab] = useState("전체");
-    const [notifications, setNotifications] = useState(dummyData);
 
-    const filtered = notifications[activeTab];
+    useEffect(() => {
+      const fetchInitialNotifications = async () => {
+        try {
+          const response = await axios.get(
+            `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications`,
+            { withCredentials: true }
+          );
+          const raw = Array.isArray(response.data)
+            ? response.data
+            : response.data.notifications || response.data.data || [];
+          const normalizedList = raw.map(n => ({
+            id: n.id,
+            title: n.title,
+            content: n.content,
+            commentId: n.commentId !== undefined ? n.commentId : n.comment_id,
+            partyId: n.partyId !== undefined ? n.partyId : n.party_id,
+            actorId: n.actorId !== undefined ? n.actorId : n.actor_id,
+            type: n.type,
+            createdAt: n.createdAt !== undefined ? n.createdAt : n.created_at,
+            isRead: n.isRead !== undefined ? n.isRead : n.is_read,
+            actorAvatarUrl: (n.actorAvatarUrl) ? n.actorAvatarUrl : ( (n.actorId || n.actor_id) ? `/avatars/${n.actorId || n.actor_id}.png` : `${process.env.PUBLIC_URL}/profile/user2.jpg` )
+          }));
+          const topTen = normalizedList
+            .sort((a, b) => b.id - a.id)
+            .slice(0, 6);
+
+          const newGrouped = {
+            전체: [],
+            직관팟: [],
+            커뮤니티: [],
+          };
+
+          topTen.forEach((notif) => {
+            newGrouped["전체"].push(notif);
+            const tabName = TYPE_TO_TAB[notif.type];
+            if (tabName) {
+              newGrouped[tabName].push(notif);
+            }
+          });
+
+          setGroupedNotifications(newGrouped);
+        } catch (err) {
+          console.error("초기 알림 조회 실패:", err);
+        }
+      };
+
+      fetchInitialNotifications();
+    }, []);
 
     const handleClearAll = () => {
-        const cleared = {};
-        for (const key in notifications) {
-            cleared[key] = notifications[key].filter(
-                (item) => item.type === "참가요청" && item.status === null
-            );
-        }
-        setNotifications(cleared);
+        // Logic to clear all notifications would go here (not implemented)
     };
 
     const handleRespond = (id, decision) => {
-        const updated = {};
-        for (const key in notifications) {
-            updated[key] = notifications[key].map((n) =>
-                n.id === id ? { ...n, status: decision } : n
-            );
-        }
-        setNotifications(updated);
+        // This function is left in place but not used until SSE or other logic is added
+    };
+
+    const handleApprove = async (item) => {
+      try {
+        await axios.patch(
+          `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${item.partyId}/approve`,
+          { applicantUserId: item.actorId, isApproved: true },
+          { withCredentials: true }
+        );
+        await axios.patch(
+          `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
+          {},
+          { withCredentials: true }
+        );
+        setGroupedNotifications(prev => {
+          const updated = { ...prev };
+          updated["전체"] = updated["전체"].filter(n => n.id !== item.id);
+          updated["직관팟"] = updated["직관팟"].filter(n => n.id !== item.id);
+          return updated;
+        });
+      } catch (err) {
+        console.error("승인 요청 처리 실패:", err);
+      }
+    };
+
+    const handleReject = async (item) => {
+      try {
+        await axios.patch(
+          `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${item.partyId}/approve`,
+          { applicantUserId: item.actorId, isApproved: false },
+          { withCredentials: true }
+        );
+        await axios.patch(
+          `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
+          {},
+          { withCredentials: true }
+        );
+        setGroupedNotifications(prev => {
+          const updated = { ...prev };
+          updated["전체"] = updated["전체"].filter(n => n.id !== item.id);
+          updated["직관팟"] = updated["직관팟"].filter(n => n.id !== item.id);
+          return updated;
+        });
+      } catch (err) {
+        console.error("거부 요청 처리 실패:", err);
+      }
     };
 
     return (
@@ -85,6 +130,7 @@ const NotificationModal = ({onClose}) => {
                 <div className={styles.header}>
                     <h3>전체 알림</h3>
                     <button onClick={handleClearAll}>전체 알림 삭제하기</button>
+                    {/*<button onClick={onClose} className={styles.closeBtn}>닫기</button>*/}
                 </div>
                 <div className={styles.tabs}>
                     {tabs.map((tab) => (
@@ -98,25 +144,82 @@ const NotificationModal = ({onClose}) => {
                     ))}
                 </div>
                 <div className={styles.notifications}>
-                    {filtered.length === 0 ? (
+                    {groupedNotifications[activeTab].filter((item) => !item.isRead).length === 0 ? (
                         <div className={styles.empty}>알림이 없습니다.</div>
                     ) : (
-                        filtered.map((item) => (
-                            <div key={item.id} className={`${styles.notificationItem} ${item.new ? styles.newAlert : ""}`}>
-                                {item.new && <span className={styles.newDot}/>}
-                                <div className={styles.notificationText}>
-                                    <strong>{item.user}</strong>님이 {item.date} {item.message}
-                                    <div className={styles.subText}>{item.content}</div>
-                                    {item.type === "참가요청" && item.status == null && (
-                                      <div className={styles.actionButtons}>
-                                        <button className={styles.approve} onClick={() => handleRespond(item.id, "승인")}>승인하기</button>
-                                        <button className={styles.reject} onClick={() => handleRespond(item.id, "거부")}>거부하기</button>
+                        groupedNotifications[activeTab]
+                          .filter((item) => !item.isRead)
+                          .map((item) => (
+                            <div key={item.id} className={`${styles.notificationItem} ${!item.isRead ? styles.newAlert : ""}`}>
+                                {!item.isRead && <span className={styles.newDot}/>}
+                                {item.type === "PARTY_REQUEST" ? (
+                                  <div className={styles.partyRequestItem}>
+                                    <img
+                                      src={item.actorAvatarUrl || "/default-avatar.png"}
+                                      alt="프로필"
+                                      className={styles.avatar}
+                                    />
+                                    <div className={styles.requestText}>
+                                      <strong>{item.title}</strong>
+                                      <div className={styles.subText}>{item.content}</div>
+                                      <div className={styles.timestamp}>
+                                        {item.createdAt
+                                          ? (() => {
+                                              const dateObj = new Date(
+                                                item.createdAt
+                                                  .replace(/\./g, "-")
+                                                  .replace(" ", "T")
+                                              );
+                                              return dateObj.toLocaleString("ko-KR", {
+                                                year: "numeric",
+                                                month: "numeric",
+                                                day: "numeric",
+                                                hour: "numeric",
+                                                minute: "numeric"
+                                              });
+                                            })()
+                                          : ""}
                                       </div>
-                                    )}
-                                    {item.type === "참가요청" && item.status !== null && (
-                                      <div className={styles.resultText}>{item.status}되었어요!</div>
-                                    )}
-                                </div>
+                                    </div>
+                                    <div className={styles.actionButtons}>
+                                      <button
+                                        className={styles.approve}
+                                        onClick={() => handleApprove(item)}
+                                      >
+                                        승인하기
+                                      </button>
+                                      <button
+                                        className={styles.reject}
+                                        onClick={() => handleReject(item)}
+                                      >
+                                        거부하기
+                                      </button>
+                                    </div>
+                                  </div>
+                                ) : (
+                                  <div className={styles.notificationItemContent}>
+                                    <strong>{item.title}</strong>
+                                    <div className={styles.subText}>{item.content}</div>
+                                    <div className={styles.timestamp}>
+                                      {item.createdAt
+                                        ? (() => {
+                                            const dateObj = new Date(
+                                              item.createdAt
+                                                .replace(/\./g, "-")
+                                                .replace(" ", "T") + (item.createdAt.includes(":") ? ":00" : "")
+                                            );
+                                            return dateObj.toLocaleString("ko-KR", {
+                                              year: "numeric",
+                                              month: "numeric",
+                                              day: "numeric",
+                                              hour: "numeric",
+                                              minute: "numeric"
+                                            });
+                                          })()
+                                        : ""}
+                                    </div>
+                                  </div>
+                                )}
                             </div>
                         ))
                     )}

--- a/src/components/Modal/NotificationModal/NotificationModal.js
+++ b/src/components/Modal/NotificationModal/NotificationModal.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from "react";
+import React, {useEffect, useState} from "react";
 import axios from "axios";
 import styles from "./NotificationModal.module.css";
 
@@ -6,72 +6,92 @@ const tabs = ["전체", "직관팟", "커뮤니티"];
 
 
 const TYPE_TO_TAB = {
-  COMMENT: "커뮤니티",
-  PARTY_REQUEST: "직관팟",
-  PARTY_JOINED: "직관팟",
-  PARTY_APPROVED: "직관팟",
-  PARTY_REFUSED: "직관팟",
+    COMMENT: "커뮤니티",
+    PARTY_REQUEST: "직관팟",
+    PARTY_JOINED: "직관팟",
+    PARTY_APPROVED: "직관팟",
+    PARTY_REFUSED: "직관팟",
 };
 
 const NotificationModal = ({onClose}) => {
     const [groupedNotifications, setGroupedNotifications] = useState({
-      전체: [],
-      직관팟: [],
-      커뮤니티: [],
+        전체: [],
+        직관팟: [],
+        커뮤니티: [],
     });
     const [activeTab, setActiveTab] = useState("전체");
 
     useEffect(() => {
-      const fetchInitialNotifications = async () => {
-        try {
-          const response = await axios.get(
-            `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications`,
-            { withCredentials: true }
-          );
-          const raw = Array.isArray(response.data)
-            ? response.data
-            : response.data.notifications || response.data.data || [];
-          const normalizedList = raw.map(n => ({
-            id: n.id,
-            title: n.title,
-            content: n.content,
-            commentId: n.commentId !== undefined ? n.commentId : n.comment_id,
-            partyId: n.partyId !== undefined ? n.partyId : n.party_id,
-            actorId: n.actorId !== undefined ? n.actorId : n.actor_id,
-            type: n.type,
-            createdAt: n.createdAt !== undefined ? n.createdAt : n.created_at,
-            isRead: n.isRead !== undefined ? n.isRead : n.is_read,
-            actorAvatarUrl: (n.actorAvatarUrl) ? n.actorAvatarUrl : ( (n.actorId || n.actor_id) ? `/avatars/${n.actorId || n.actor_id}.png` : `${process.env.PUBLIC_URL}/profile/user2.jpg` )
-          }));
-          const topTen = normalizedList
-            .sort((a, b) => b.id - a.id)
-            .slice(0, 6);
+        const fetchInitialNotifications = async () => {
+            try {
+                const response = await axios.get(
+                    `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications`,
+                    {withCredentials: true}
+                );
+                const raw = Array.isArray(response.data)
+                    ? response.data
+                    : response.data.notifications || response.data.data || [];
+                const normalizedList = raw.map(n => ({
+                    id: n.id,
+                    title: n.title,
+                    content: n.content,
+                    commentId: n.commentId !== undefined ? n.commentId : n.comment_id,
+                    partyId: n.partyId !== undefined ? n.partyId : n.party_id,
+                    actorId: n.actorId !== undefined ? n.actorId : n.actor_id,
+                    type: n.type,
+                    createdAt: n.createdAt !== undefined ? n.createdAt : n.created_at,
+                    isRead: n.isRead !== undefined ? n.isRead : n.is_read,
+                    actorAvatarUrl: (n.actorAvatarUrl) ? n.actorAvatarUrl : ((n.actorId || n.actor_id) ? `/avatars/${n.actorId || n.actor_id}.png` : `${process.env.PUBLIC_URL}/profile/user2.jpg`)
+                }));
+                const topTen = normalizedList
+                    .sort((a, b) => b.id - a.id)
+                    .slice(0, 6);
 
-          const newGrouped = {
-            전체: [],
-            직관팟: [],
-            커뮤니티: [],
-          };
+                const newGrouped = {
+                    전체: [],
+                    직관팟: [],
+                    커뮤니티: [],
+                };
 
-          topTen.forEach((notif) => {
-            newGrouped["전체"].push(notif);
-            const tabName = TYPE_TO_TAB[notif.type];
-            if (tabName) {
-              newGrouped[tabName].push(notif);
+                topTen.forEach((notif) => {
+                    newGrouped["전체"].push(notif);
+                    const tabName = TYPE_TO_TAB[notif.type];
+                    if (tabName) {
+                        newGrouped[tabName].push(notif);
+                    }
+                });
+
+                setGroupedNotifications(newGrouped);
+            } catch (err) {
+                console.error("초기 알림 조회 실패:", err);
             }
-          });
+        };
 
-          setGroupedNotifications(newGrouped);
-        } catch (err) {
-          console.error("초기 알림 조회 실패:", err);
-        }
-      };
-
-      fetchInitialNotifications();
+        fetchInitialNotifications();
     }, []);
 
-    const handleClearAll = () => {
-        // Logic to clear all notifications would go here (not implemented)
+    const handleClearAll = async () => {
+        try {
+            const allNotifications = groupedNotifications["전체"];
+            // Mark each notification as read via API
+            await Promise.all(
+                allNotifications.map((item) =>
+                    axios.patch(
+                        `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
+                        {},
+                        {withCredentials: true}
+                    )
+                )
+            );
+            // After marking all as read, clear state so none remain
+            setGroupedNotifications({
+                전체: [],
+                직관팟: [],
+                커뮤니티: [],
+            });
+        } catch (err) {
+            console.error("전체 알림 읽기 처리 실패:", err);
+        }
     };
 
     const handleRespond = (id, decision) => {
@@ -79,49 +99,49 @@ const NotificationModal = ({onClose}) => {
     };
 
     const handleApprove = async (item) => {
-      try {
-        await axios.patch(
-          `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${item.partyId}/approve`,
-          { applicantUserId: item.actorId, isApproved: true },
-          { withCredentials: true }
-        );
-        await axios.patch(
-          `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
-          {},
-          { withCredentials: true }
-        );
-        setGroupedNotifications(prev => {
-          const updated = { ...prev };
-          updated["전체"] = updated["전체"].filter(n => n.id !== item.id);
-          updated["직관팟"] = updated["직관팟"].filter(n => n.id !== item.id);
-          return updated;
-        });
-      } catch (err) {
-        console.error("승인 요청 처리 실패:", err);
-      }
+        try {
+            await axios.patch(
+                `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${item.partyId}/approve`,
+                {applicantUserId: item.actorId, isApproved: true},
+                {withCredentials: true}
+            );
+            await axios.patch(
+                `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
+                {},
+                {withCredentials: true}
+            );
+            setGroupedNotifications(prev => {
+                const updated = {...prev};
+                updated["전체"] = updated["전체"].filter(n => n.id !== item.id);
+                updated["직관팟"] = updated["직관팟"].filter(n => n.id !== item.id);
+                return updated;
+            });
+        } catch (err) {
+            console.error("승인 요청 처리 실패:", err);
+        }
     };
 
     const handleReject = async (item) => {
-      try {
-        await axios.patch(
-          `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${item.partyId}/approve`,
-          { applicantUserId: item.actorId, isApproved: false },
-          { withCredentials: true }
-        );
-        await axios.patch(
-          `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
-          {},
-          { withCredentials: true }
-        );
-        setGroupedNotifications(prev => {
-          const updated = { ...prev };
-          updated["전체"] = updated["전체"].filter(n => n.id !== item.id);
-          updated["직관팟"] = updated["직관팟"].filter(n => n.id !== item.id);
-          return updated;
-        });
-      } catch (err) {
-        console.error("거부 요청 처리 실패:", err);
-      }
+        try {
+            await axios.patch(
+                `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${item.partyId}/approve`,
+                {applicantUserId: item.actorId, isApproved: false},
+                {withCredentials: true}
+            );
+            await axios.patch(
+                `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/notifications/read/${item.id}`,
+                {},
+                {withCredentials: true}
+            );
+            setGroupedNotifications(prev => {
+                const updated = {...prev};
+                updated["전체"] = updated["전체"].filter(n => n.id !== item.id);
+                updated["직관팟"] = updated["직관팟"].filter(n => n.id !== item.id);
+                return updated;
+            });
+        } catch (err) {
+            console.error("거부 요청 처리 실패:", err);
+        }
     };
 
     return (
@@ -148,80 +168,81 @@ const NotificationModal = ({onClose}) => {
                         <div className={styles.empty}>알림이 없습니다.</div>
                     ) : (
                         groupedNotifications[activeTab]
-                          .filter((item) => !item.isRead)
-                          .map((item) => (
-                            <div key={item.id} className={`${styles.notificationItem} ${!item.isRead ? styles.newAlert : ""}`}>
-                                {!item.isRead && <span className={styles.newDot}/>}
-                                {item.type === "PARTY_REQUEST" ? (
-                                  <div className={styles.partyRequestItem}>
-                                    <img
-                                      src={item.actorAvatarUrl || "/default-avatar.png"}
-                                      alt="프로필"
-                                      className={styles.avatar}
-                                    />
-                                    <div className={styles.requestText}>
-                                      <strong>{item.title}</strong>
-                                      <div className={styles.subText}>{item.content}</div>
-                                      <div className={styles.timestamp}>
-                                        {item.createdAt
-                                          ? (() => {
-                                              const dateObj = new Date(
-                                                item.createdAt
-                                                  .replace(/\./g, "-")
-                                                  .replace(" ", "T")
-                                              );
-                                              return dateObj.toLocaleString("ko-KR", {
-                                                year: "numeric",
-                                                month: "numeric",
-                                                day: "numeric",
-                                                hour: "numeric",
-                                                minute: "numeric"
-                                              });
-                                            })()
-                                          : ""}
-                                      </div>
-                                    </div>
-                                    <div className={styles.actionButtons}>
-                                      <button
-                                        className={styles.approve}
-                                        onClick={() => handleApprove(item)}
-                                      >
-                                        승인하기
-                                      </button>
-                                      <button
-                                        className={styles.reject}
-                                        onClick={() => handleReject(item)}
-                                      >
-                                        거부하기
-                                      </button>
-                                    </div>
-                                  </div>
-                                ) : (
-                                  <div className={styles.notificationItemContent}>
-                                    <strong>{item.title}</strong>
-                                    <div className={styles.subText}>{item.content}</div>
-                                    <div className={styles.timestamp}>
-                                      {item.createdAt
-                                        ? (() => {
-                                            const dateObj = new Date(
-                                              item.createdAt
-                                                .replace(/\./g, "-")
-                                                .replace(" ", "T") + (item.createdAt.includes(":") ? ":00" : "")
-                                            );
-                                            return dateObj.toLocaleString("ko-KR", {
-                                              year: "numeric",
-                                              month: "numeric",
-                                              day: "numeric",
-                                              hour: "numeric",
-                                              minute: "numeric"
-                                            });
-                                          })()
-                                        : ""}
-                                    </div>
-                                  </div>
-                                )}
-                            </div>
-                        ))
+                            .filter((item) => !item.isRead)
+                            .map((item) => (
+                                <div key={item.id}
+                                     className={`${styles.notificationItem} ${!item.isRead ? styles.newAlert : ""}`}>
+                                    {!item.isRead && <span className={styles.newDot}/>}
+                                    {item.type === "PARTY_REQUEST" ? (
+                                        <div className={styles.partyRequestItem}>
+                                            <img
+                                                src={item.actorAvatarUrl || "/default-avatar.png"}
+                                                alt="프로필"
+                                                className={styles.avatar}
+                                            />
+                                            <div className={styles.requestText}>
+                                                <strong>{item.title}</strong>
+                                                <div className={styles.subText}>{item.content}</div>
+                                                <div className={styles.timestamp}>
+                                                    {item.createdAt
+                                                        ? (() => {
+                                                            const dateObj = new Date(
+                                                                item.createdAt
+                                                                    .replace(/\./g, "-")
+                                                                    .replace(" ", "T")
+                                                            );
+                                                            return dateObj.toLocaleString("ko-KR", {
+                                                                year: "numeric",
+                                                                month: "numeric",
+                                                                day: "numeric",
+                                                                hour: "numeric",
+                                                                minute: "numeric"
+                                                            });
+                                                        })()
+                                                        : ""}
+                                                </div>
+                                            </div>
+                                            <div className={styles.actionButtons}>
+                                                <button
+                                                    className={styles.approve}
+                                                    onClick={() => handleApprove(item)}
+                                                >
+                                                    승인하기
+                                                </button>
+                                                <button
+                                                    className={styles.reject}
+                                                    onClick={() => handleReject(item)}
+                                                >
+                                                    거부하기
+                                                </button>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className={styles.notificationItemContent}>
+                                            <strong>{item.title}</strong>
+                                            <div className={styles.subText}>{item.content}</div>
+                                            <div className={styles.timestamp}>
+                                                {item.createdAt
+                                                    ? (() => {
+                                                        const dateObj = new Date(
+                                                            item.createdAt
+                                                                .replace(/\./g, "-")
+                                                                .replace(" ", "T") + (item.createdAt.includes(":") ? ":00" : "")
+                                                        );
+                                                        return dateObj.toLocaleString("ko-KR", {
+                                                            year: "numeric",
+                                                            month: "numeric",
+                                                            day: "numeric",
+                                                            hour: "numeric",
+                                                            minute: "numeric"
+                                                        });
+                                                    })()
+                                                    : ""}
+                                            </div>
+                                        </div>
+                                    )}
+                                </div>
+                            ))
                     )}
                 </div>
             </div>

--- a/src/pages/Main/MainPage.js
+++ b/src/pages/Main/MainPage.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-import React, {useEffect, useState} from "react";
+import React, {useEffect, useState, useRef} from "react";
 import styles from "./MainPage.module.css";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import CasterbotModal from "../Chatbot/CasterbotModal";
@@ -50,6 +50,46 @@ export default function MainPage() {
         };
 
         fetchUserProfileAndFavorites();
+    }, []);
+
+    // Reference to hold EventSource instance
+    const eventSourceRef = useRef(null);
+
+    // SSE 구독: 로그인 후 "/home"에 도착할 때 바로 실행
+    useEffect(() => {
+      const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
+      // 브라우저 기본 EventSource는 쿠키에 들어있는 JWT를 자동으로 포함
+      const sseUrl = `${baseUrl}/user/notifications/connect`;
+      const es = new EventSource(sseUrl, { withCredentials: true });
+      eventSourceRef.current = es;
+
+      // 서버가 전송하는 이벤트를 받을 때 처리
+      es.onmessage = (e) => {
+        const text = e.data;
+        if (text.trim().startsWith("{")) {
+          try {
+            const notification = JSON.parse(text);
+            console.log("새 알림 도착:", notification);
+            // TODO: 받은 알림을 상태나 Context에 저장하여 화면에 반영
+          } catch (err) {
+            console.error("JSON 파싱 중 오류:", err);
+          }
+        } else {
+          console.log("SSE 비-JSON 메시지:", text);
+        }
+      };
+
+      es.onerror = (err) => {
+        console.error("SSE 연결 오류:", err);
+        // 필요 시 재연결 로직 추가 가능
+      };
+
+      // 컴포넌트 언마운트 시에는 EventSource 닫기
+      return () => {
+        if (eventSourceRef.current) {
+          eventSourceRef.current.close();
+        }
+      };
     }, []);
 
     const handleOpenModal = () => {

--- a/src/pages/Main/MainPage.js
+++ b/src/pages/Main/MainPage.js
@@ -20,9 +20,47 @@ export default function MainPage() {
     const [favoriteMap, setFavoriteMap] = useState({});
     const [selectedFavorites, setSelectedFavorites] = useState([]);
 
+    const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
+    const sseUrl = `${baseUrl}/user/notifications/connect`;
+
+    // Reference to hold EventSource instance
+    const eventSourceRef = useRef(null);
+
+    function setupEventHandlers(es) {
+      // 서버가 전송하는 이벤트를 받을 때 처리
+      es.onmessage = (e) => {
+        const text = e.data;
+        if (text.trim().startsWith("{")) {
+          try {
+            const notification = JSON.parse(text);
+            console.log("새 알림 도착:", notification);
+            // TODO: 받은 알림을 상태나 Context에 저장하여 화면에 반영
+          } catch (err) {
+            console.error("JSON 파싱 중 오류:", err);
+          }
+        } else {
+          console.log("SSE 비-JSON 메시지:", text);
+        }
+      };
+
+      es.onerror = (err) => {
+        console.error("SSE 연결 오류:", err);
+          if (es.readyState === EventSource.CLOSED) {
+                  console.log("SSE 연결이 닫혔습니다. 5초 후 재연결 시도...");
+                  setTimeout(() => {
+                        if (eventSourceRef.current === es) {
+                              const newEs = new EventSource(sseUrl, { withCredentials: true });
+                              eventSourceRef.current = newEs;
+                              // 이벤트 핸들러 재설정
+                                  setupEventHandlers(newEs);
+                            }
+                      }, 5000);
+                }
+      };
+    }
+
     useEffect(() => {
         const fetchUserProfileAndFavorites = async () => {
-            const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
             try {
                 const res = await axios.get(`${baseUrl}/user/profile`, {withCredentials: true});
                 const favorites = res.data.favoriteTeams;
@@ -52,37 +90,13 @@ export default function MainPage() {
         fetchUserProfileAndFavorites();
     }, []);
 
-    // Reference to hold EventSource instance
-    const eventSourceRef = useRef(null);
-
     // SSE 구독: 로그인 후 "/home"에 도착할 때 바로 실행
     useEffect(() => {
-      const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
       // 브라우저 기본 EventSource는 쿠키에 들어있는 JWT를 자동으로 포함
-      const sseUrl = `${baseUrl}/user/notifications/connect`;
       const es = new EventSource(sseUrl, { withCredentials: true });
       eventSourceRef.current = es;
 
-      // 서버가 전송하는 이벤트를 받을 때 처리
-      es.onmessage = (e) => {
-        const text = e.data;
-        if (text.trim().startsWith("{")) {
-          try {
-            const notification = JSON.parse(text);
-            console.log("새 알림 도착:", notification);
-            // TODO: 받은 알림을 상태나 Context에 저장하여 화면에 반영
-          } catch (err) {
-            console.error("JSON 파싱 중 오류:", err);
-          }
-        } else {
-          console.log("SSE 비-JSON 메시지:", text);
-        }
-      };
-
-      es.onerror = (err) => {
-        console.error("SSE 연결 오류:", err);
-        // 필요 시 재연결 로직 추가 가능
-      };
+      setupEventHandlers(es);
 
       // 컴포넌트 언마운트 시에는 EventSource 닫기
       return () => {
@@ -102,7 +116,6 @@ export default function MainPage() {
     };
 
     const handleSelectTeam = async () => {
-        const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
         try {
             const requests = selectedFavorites.map((teamId, index) => ({
                 teamId,

--- a/src/utils/formatNotificationDate.js
+++ b/src/utils/formatNotificationDate.js
@@ -1,0 +1,25 @@
+export const formatNotificationDate = (dateString) => {
+    if (!dateString) return "";
+
+    try {
+        // "2024.01.15 14:30" 형식을 ISO 형식으로 변환
+        let isoString = dateString.replace(/\./g, "-").replace(" ", "T");
+
+        // 초가 없는 경우 추가
+        if (!isoString.includes(":", isoString.lastIndexOf(":")+1)) {
+            isoString += ":00";
+        }
+
+        const dateObj = new Date(isoString);
+        return dateObj.toLocaleString("ko-KR", {
+            year: "numeric",
+            month: "numeric",
+            day: "numeric",
+            hour: "numeric",
+            minute: "numeric"
+        });
+    } catch (error) {
+        console.error("날짜 파싱 오류:", error);
+        return dateString; // 파싱 실패 시 원본 반환
+    }
+};

--- a/src/utils/formatNotificationDate.js
+++ b/src/utils/formatNotificationDate.js
@@ -5,8 +5,7 @@ export const formatNotificationDate = (dateString) => {
         // "2024.01.15 14:30" 형식을 ISO 형식으로 변환
         let isoString = dateString.replace(/\./g, "-").replace(" ", "T");
 
-        // 초가 없는 경우 추가
-        if (!isoString.includes(":", isoString.lastIndexOf(":")+1)) {
+        if (isoString.split("T")[1] && isoString.split("T")[1].split(":").length === 2) {
             isoString += ":00";
         }
 


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 알림 조회 API 연동 구현
<img width="312" alt="image" src="https://github.com/user-attachments/assets/d4b05589-bff1-41f1-b2df-c55b6d24cd8b" />

- 로그인 시 SSE 구독 후, 사용자에게 오는 메시지를 '직관팟'과 '커뮤니티 댓글'로 구분하여 사용자에게 제공
- 알림 모달에서는 최신 알림 6개만 보이도록 제한
- 전체 알림 삭제 클릭 시 DB 삭제가 아닌 isRead 변경을 통해 사용자에게 true인 값을 보여주지 않도록 구현

### 2. 직관팟 승인/거부 연동
<img width="312" alt="image" src="https://github.com/user-attachments/assets/c2b44fc5-bd45-4e46-b3b5-0dc3ba81429a" />

- 승인 혹은 거부 버튼 클릭 시, 해당 직관팟에 발신자가 가입/가입 거부되도록 연동
- 선착순의 경우 사용자 입장 시 곧바로 파티장에게 입장 알림 전송

---

## 🔗 관련 이슈
- closes #93 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 알림 모달에서 실제 백엔드 API로부터 알림을 불러오고, 최신 6개 알림을 유형별로 탭에 맞게 분류하여 표시합니다.
  - "직관팟" 관련 알림에 대해 승인/거절 버튼이 제공되며, 해당 작업 시 알림이 읽음 처리되고 목록에서 제거됩니다.
  - "전체 읽음" 버튼이 모든 알림을 읽음 처리합니다.
  - 메인 페이지에 서버-센트 이벤트(SSE)를 통한 실시간 알림 수신 기능이 추가되었습니다.
  - 알림 날짜를 한국어 형식으로 보기 좋게 변환하는 기능이 추가되었습니다.

- **리팩터**
  - 알림 모달의 상태 관리 및 렌더링 로직이 동적 데이터에 맞게 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->