### PR TITLE
Cs 378 feat/검색 결과 페이지 및 실시간 검색어 api 연결

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,11 +25,12 @@
     "react/prop-types": "off",
     "no-unused-vars": "off",
     "no-console": "off",
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    "no-undef": "off"
   },
   "settings": {
     "react": {
       "version": "detect"
     }
   }
-} 
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,8 +25,7 @@
     "react/prop-types": "off",
     "no-unused-vars": "off",
     "no-console": "off",
-    "react-hooks/exhaustive-deps": "off",
-    "no-undef": "off"
+    "react-hooks/exhaustive-deps": "off"
   },
   "settings": {
     "react": {

--- a/src/components/Header/MainHeader/Header.js
+++ b/src/components/Header/MainHeader/Header.js
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
+import axios from "axios";
 import NotificationModal from "../../Modal/NotificationModal/NotificationModal";
 import {useNavigate} from "react-router-dom";
 import styles from "./Header.module.css";
@@ -7,6 +8,51 @@ import {useSearch} from "../../SearchContext";
 const Header = () => {
     const {inputValue, setInputValue, setKeyword} = useSearch();
     const navigate = useNavigate();
+
+    // 실시간 인기 검색어 state
+    const [trendingList, setTrendingList] = useState([]);
+    const [showDropdown, setShowDropdown] = useState(false);
+    const blurTimeoutRef = useRef(null);
+
+    // 입력창 포커스 시 인기 검색어 조회
+    const handleInputFocus = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_LOCAL_BACKEND_SEARCH_URI}/search/trending`,
+          { withCredentials: true }
+        );
+        setTrendingList(response.data);
+        setShowDropdown(true);
+      } catch (err) {
+        console.error("실시간 검색어 조회 중 에러:", err);
+        setTrendingList([]);
+        setShowDropdown(false);
+      }
+    };
+
+    // 입력창 블러 시 드롭다운 숨기기 (잠시 지연)
+    const handleInputBlur = () => {
+      blurTimeoutRef.current = setTimeout(() => {
+        setShowDropdown(false);
+      }, 200);
+    };
+
+    // 입력값 변경 시 드롭다운 숨기기
+    const handleInputChange = (e) => {
+      setInputValue(e.target.value);
+      setShowDropdown(false);
+      if (blurTimeoutRef.current) {
+        clearTimeout(blurTimeoutRef.current);
+      }
+    };
+
+    // 드롭다운 항목 클릭 시
+    const handleKeywordClick = (keyword) => {
+      setInputValue(keyword);
+      setKeyword(keyword);
+      navigate("/search");
+      setShowDropdown(false);
+    };
 
     const [showModal, setShowModal] = useState(false);
 
@@ -37,19 +83,35 @@ const Header = () => {
                     className={styles.header_search_input}
                     placeholder="검색어 입력..."
                     value={inputValue}
-                    onChange={(e) => setInputValue(e.target.value)}
+                    onChange={handleInputChange}
                     onKeyDown={handleKeyDown}
+                    onFocus={handleInputFocus}
+                    onBlur={handleInputBlur}
                 />
+                {showDropdown && trendingList.length > 0 && (
+                  <ul className={styles.searchDropdown}>
+                    {trendingList.slice(0, 5).map((item) => (
+                      <li
+                        key={item.rank}
+                        className={styles.dropdownItem}
+                        onClick={() => handleKeywordClick(item.keyword)}
+                      >
+                        <span className={styles.rank}>{item.rank}.</span>
+                        <span className={styles.keyword}>{item.keyword}</span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
             </div>
             <div className={`${styles.header_right} ${styles.header_right_absolute}`}>
-                <button>
-                    {/* 관리자 기능은 현재 Non-MVP이므로 미구현 */}
-                    <img
-                        src={`${process.env.PUBLIC_URL}/Button/admin.png`}
-                        alt="관리자"
-                        className={styles.noti_alert}
-                    />
-                </button>
+                {/*<button>*/}
+                {/*    /!* 관리자 기능은 현재 Non-MVP이므로 미구현 *!/*/}
+                {/*    <img*/}
+                {/*        src={`${process.env.PUBLIC_URL}/Button/admin.png`}*/}
+                {/*        alt="관리자"*/}
+                {/*        className={styles.noti_alert}*/}
+                {/*    />*/}
+                {/*</button>*/}
                 <button onClick={() => setShowModal(!showModal)}>
                     <img
                         src={`${process.env.PUBLIC_URL}/Button/alert.png`}

--- a/src/components/Header/MainHeader/Header.module.css
+++ b/src/components/Header/MainHeader/Header.module.css
@@ -58,7 +58,7 @@
     list-style: none;
     padding: 4px 0;
     margin: 0;
-    z-index: 999;
+    z-index: 100;
 }
 
 .dropdownItem {

--- a/src/components/Header/MainHeader/Header.module.css
+++ b/src/components/Header/MainHeader/Header.module.css
@@ -36,13 +36,51 @@
     width: 90%;
     height: 43px;
 
-    padding-left: 2%;
+    padding-left: 4%;
 
     background: #F4F4F4;
     border: 0.2vw solid #0F62FE;
     border-radius: 50px;
 
     font-size: 1rem;
+}
+
+/* 검색창 드롭다운 */
+.searchDropdown {
+    position: absolute;
+    top: 50px; /* 필요에 따라 input 높이만큼 조정하세요 */
+    left: 5%;  /* input 위치가 5% 패딩을 가지고 있으므로 동일하게 맞춥니다 */
+    width: 90%; /* input과 같은 너비로 설정 */
+    background-color: #ffffff;
+    border: 1px solid #dddddd;
+    border-radius: 4px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+    list-style: none;
+    padding: 4px 0;
+    margin: 0;
+    z-index: 999;
+}
+
+.dropdownItem {
+    display: flex;
+    align-items: center;
+    padding: 6px 12px;
+    cursor: pointer;
+}
+.dropdownItem:hover {
+    background-color: #f5f5f5;
+}
+
+.rank {
+    margin-right: 8px;
+    font-weight: 500;
+    color: #666666;
+}
+
+.keyword {
+    flex: 1;
+    font-size: 0.9rem;
+    color: #333333;
 }
 
 .header_right {

--- a/src/pages/Community/Community.js
+++ b/src/pages/Community/Community.js
@@ -40,6 +40,7 @@ const teams = [
 ];
 
 const Community = () => {
+  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
   const searchParams = new URLSearchParams(location.search);
@@ -210,7 +211,7 @@ const Community = () => {
     };
   }, [showModal]);
 
-  const handlePostClick = (postId, team) => {
+  const handlePostClick = (team, postId) => {
     navigate(`/community/post/${team}/${postId}`);
   };
 
@@ -243,7 +244,7 @@ const Community = () => {
       alert('팀을 선택해주세요.');
       return;
     }
-    
+
     // teamInfoMapCommunity에서 선택한 팀 정보 찾기
     const selectedTeamInfo = teamInfoMapCommunity.find(team => team.teamId === tempTeam);
     if (!selectedTeamInfo) {
@@ -307,8 +308,8 @@ const Community = () => {
     const normalize = v => (v || '').replace(/_/g, '').toUpperCase();
     const normalizedPostTeam = normalize(post.team);
     const normalizedSelectedTeam = normalize(selectedTeam);
-    console.log('팀 비교:', { 
-      postTeam: post.team, 
+    console.log('팀 비교:', {
+      postTeam: post.team,
       normalizedPostTeam,
       selectedTeam,
       normalizedSelectedTeam,
@@ -349,7 +350,7 @@ const Community = () => {
               time={post.time}
               author={post.author}
               image={post.image}
-              onClick={() => handlePostClick(post.id || post.postId, post.team)}
+              onClick={() => handlePostClick(post.team, post.id || post.postId)}
             />
           ))
         )}

--- a/src/pages/Community/PostDetail.js
+++ b/src/pages/Community/PostDetail.js
@@ -531,7 +531,7 @@ const PostDetail = () => {
                              alt="프로필"
                              onError={(e) => {
                                  e.target.onerror = null;
-                                 e.target.src = `${process.env.PUBLIC_URL}/profile/default.png`;
+                                 // e.target.src = `${process.env.PUBLIC_URL}/profile/default.png`;
                              }}
                         />
                         <span className={styles.profileName}>{post.writerNickname}</span>

--- a/src/pages/Community/PostDetail.js
+++ b/src/pages/Community/PostDetail.js
@@ -321,7 +321,7 @@ const PostDetail = () => {
 
         try {
             const response = await axios.delete(
-                `${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/post/${postId}`,
+                `${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/post/${teamParam}/${postId}`,
                 {
                     withCredentials: true,
                     headers: {

--- a/src/pages/Community/SearchResultPage.js
+++ b/src/pages/Community/SearchResultPage.js
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import styles from "./SearchResultPage.module.css";
 import { useSearch } from "../../components/SearchContext";
 import PostListItem from "../../components/Post/PostListItem";
+import axios from "axios";
 
 const SearchResultPage = () => {
   const { keyword } = useSearch();
@@ -11,25 +12,39 @@ const SearchResultPage = () => {
   const [posts, setPosts] = useState([]);
 
   useEffect(() => {
-    try {
-      const saved = JSON.parse(localStorage.getItem('communityPosts')) || [];
-      setPosts(saved);
-    } catch (error) {
-      console.error('게시물 데이터 로드 중 오류 발생:', error);
+    // 검색 키워드(keyword)가 비어 있으면 빈 배열로 초기화
+    if (!keyword || keyword.trim() === "") {
       setPosts([]);
+      return;
     }
-  }, []);
 
-  const filtered = posts.filter(
-    (post) => post.title && post.title.toLowerCase().includes(safeKeyword)
-  );
+    const fetchSearchResults = async () => {
+      try {
+        const response = await axios.get(
+          `${process.env.REACT_APP_LOCAL_BACKEND_SEARCH_URI}/search/posts`,
+          {
+            params: { query: keyword },
+            withCredentials: true,
+          }
+        );
+        // 백엔드 응답: { resultSize: number, searchResultList: [ { postId, writerName, title, thumbnailUrl, createdAt, tag }, ... ] }
+        const resultList = response.data.searchResultList || [];
+        setPosts(resultList);
+      } catch (err) {
+        console.error("검색 API 호출 중 오류:", err);
+        setPosts([]);
+      }
+    };
+
+    fetchSearchResults();
+  }, [keyword]);
 
   const handleBack = () => {
     navigate(-1);
   };
 
-  const handlePostClick = (postId) => {
-    navigate(`/community/post/${postId}`);
+  const handlePostClick = (team, postId) => {
+    navigate(`/community/post/${team}/${postId}`);
   };
 
   return (
@@ -45,20 +60,20 @@ const SearchResultPage = () => {
 
       {/* 검색 결과 요약 및 0건 안내 */}
       <div className={styles.summary}>
-        {filtered.length > 0
-          ? <>총 <strong>{filtered.length}</strong>건의 검색결과가 있습니다.</>
+        {posts.length > 0
+          ? <>총 <strong>{posts.length}</strong>건의 검색결과가 있습니다.</>
           : "검색 결과가 없습니다."}
       </div>
 
       <ul className={styles.list}>
-        {filtered.length > 0 && filtered.map((post) => (
+        {posts.length > 0 && posts.map((item) => (
           <PostListItem
-            key={post.id}
-            title={post.title}
-            time={post.time}
-            author={post.author}
-            image={post.image}
-            onClick={() => handlePostClick(post.id)}
+            key={item.postId}
+            title={item.title}
+            time={item.createdAt}
+            author={item.writerName}
+            image={item.thumbnailUrl}
+            onClick={() => handlePostClick(item.tag, item.postId)}
           />
         ))}
       </ul>

--- a/src/pages/Community/SearchResultPage.js
+++ b/src/pages/Community/SearchResultPage.js
@@ -27,7 +27,7 @@ const SearchResultPage = () => {
             withCredentials: true,
           }
         );
-        // 백엔드 응답: { resultSize: number, searchResultList: [ { postId, writerName, title, thumbnailUrl, createdAt, tag }, ... ] }
+        // 백엔드 응답: { resultSize: number, searchResultList: [ { postId, writerName, title, thumbnailUrl, createdAt, teamTag }, ... ] }
         const resultList = response.data.searchResultList || [];
         setPosts(resultList);
       } catch (err) {
@@ -73,7 +73,7 @@ const SearchResultPage = () => {
             time={item.createdAt}
             author={item.writerName}
             image={item.thumbnailUrl}
-            onClick={() => handlePostClick(item.tag, item.postId)}
+            onClick={() => handlePostClick(item.teamTag, item.postId)}
           />
         ))}
       </ul>

--- a/src/pages/Main/MainPage.js
+++ b/src/pages/Main/MainPage.js
@@ -1,5 +1,7 @@
 import axios from "axios";
 import React, {useEffect, useState, useRef} from "react";
+import { useAuth} from "../../utils/AuthContext";
+import { useNavigate } from "react-router-dom";
 import styles from "./MainPage.module.css";
 import CasterbotButton from "../../components/CasterbotButton/CasterbotButton";
 import CasterbotModal from "../Chatbot/CasterbotModal";
@@ -9,6 +11,8 @@ import DummyMatchData from "../../components/DummyData/DummyMatchData";
 import {teamInfoMap} from "../../utils/teamInfoMap";
 
 export default function MainPage() {
+    const { user } = useAuth();
+    const loginUserId = user?.id;
     const [showCasterbot, setShowCasterbot] = useState(false);
     const [teams2, setTeams2] = useState([]);
     const [activeTeamIndex, setActiveTeamIndex] = useState(0);
@@ -20,10 +24,13 @@ export default function MainPage() {
     const [favoriteMap, setFavoriteMap] = useState({});
     const [selectedFavorites, setSelectedFavorites] = useState([]);
     const [allMatches, setAllMatches] = useState([]);
+    const [myApprovalPartyDetail, setMyApprovalPartyDetail] = useState(null);
     const today = new Date().toISOString().split("T")[0];
 
     const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
     const sseUrl = `${baseUrl}/user/notifications/connect`;
+
+    const navigate = useNavigate();
 
     // Reference to hold EventSource instance
     const eventSourceRef = useRef(null);
@@ -93,6 +100,36 @@ export default function MainPage() {
 
         fetchUserProfileAndFavorites();
     }, []);
+
+    useEffect(() => {
+      const fetchMyApprovalPartyDetail = async () => {
+        if (!loginUserId) return;
+        try {
+          const twpBase = process.env.REACT_APP_LOCAL_BACKEND_TWP_URI;
+          const listRes = await axios.get(
+            `${twpBase}/party`,
+            {
+              params: { matchId: 1, deletedAt: null },
+              withCredentials: true
+            }
+          );
+          const myParties = listRes.data.filter(
+            (p) => p.writerId === loginUserId
+          );
+          if (myParties.length > 0) {
+            const partyId = myParties[0].partyId;
+            const detailRes = await axios.get(
+              `${twpBase}/party/${partyId}`,
+              { withCredentials: true }
+            );
+            setMyApprovalPartyDetail(detailRes.data);
+          }
+        } catch (err) {
+          console.error("내가 승인한 직관팟 정보 조회 실패:", err);
+        }
+      };
+      fetchMyApprovalPartyDetail();
+    }, [loginUserId]);
 
     // SSE 구독: 로그인 후 "/home"에 도착할 때 바로 실행
     useEffect(() => {
@@ -191,6 +228,10 @@ export default function MainPage() {
         }
       : null;
 
+    const onEnterChat = (chatRoomId) => {
+      navigate(`/chat/party/${chatRoomId}`);
+    };
+
     return (
         <div className={styles.main_page}>
             <TeamTabNav
@@ -216,6 +257,63 @@ export default function MainPage() {
                 {/*)}*/}
             </div>
             <h2 className={styles.sectionTitleWithMargin}>나의 직관팟</h2>
+            {myApprovalPartyDetail && (
+              <div
+                className={styles.partyCard}
+                onClick={() => onEnterChat(myApprovalPartyDetail.partyId)}
+                style={{ cursor: "pointer" }}
+              >
+                <img
+                  src={myApprovalPartyDetail.partyThumbnailUrls?.[0] || `${process.env.PUBLIC_URL}/Logo/jikgwanprofile.png`}
+                  alt="직관팟 썸네일"
+                  className={styles.playerImg}
+                />
+                <div className={styles.partyContent}>
+                  <div className={styles.tags}>
+                    <span className={styles.tag}>{myApprovalPartyDetail.partyJoinMethod}</span>
+                    {myApprovalPartyDetail.partyAges?.map((tag, index) => (
+                      <span
+                        key={index}
+                        className={`${styles.tag} ${index === 2 ? styles.tagHighlight : ''}`}
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                    <span className={`${styles.tag} ${styles.tagHighlight}`}>
+                      {myApprovalPartyDetail.availableGender}
+                    </span>
+                  </div>
+                  <div className={styles.partyTitle}>{myApprovalPartyDetail.title}</div>
+                  <div className={styles.partyMeta}>
+                    <span>{myApprovalPartyDetail.authorName || '작성자'}</span>
+                    <span>{myApprovalPartyDetail.authorAge || '나이'}</span>
+                    <span>
+                      {myApprovalPartyDetail.authorGender === 'MALE'
+                        ? '남성'
+                        : myApprovalPartyDetail.authorGender === 'FEMALE'
+                          ? '여성'
+                          : '기타'}
+                    </span>
+                    <span>· {myApprovalPartyDetail.matchDate}</span>
+                  </div>
+
+                  <div className={styles.partyStatus}>
+                    <div className={styles.avatars}>
+                      {myApprovalPartyDetail.userThumbnailUrls?.slice(0, 1).map((url, i) => (
+                        <img
+                          key={i}
+                          src={url || `${process.env.PUBLIC_URL}/Logo/profile.png`}
+                          alt="프로필"
+                        />
+                      ))}
+                    </div>
+                    <div className={styles.slot}>
+                      {myApprovalPartyDetail.currentParticipantsCount}/{myApprovalPartyDetail.maximumParticipantsCount}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
             {/* TODO: 이후 ISSUE에서 TWP SERVICE merge 이후 적용 예정 */}
             {/*{parties.length > 0 ? (*/}
             {/*    parties.map((party, i) => <MyPartyCard key={i} {...party} />)*/}

--- a/src/pages/Main/MainPage.module.css
+++ b/src/pages/Main/MainPage.module.css
@@ -197,3 +197,94 @@
     width: 34px;
     height: 24px;
 }
+
+/* section 2 */
+.partyCard {
+    display: flex;
+    background-color: #f9f9f9;
+    border-radius: 10px;
+    overflow: hidden;
+    padding: 1rem;
+}
+
+.playerImg {
+    width: 7rem;
+    height: 7rem;
+    align-self: center;
+    border-radius: 8px;
+    object-fit: cover;
+    margin: 0 1.5rem 0 0;
+}
+
+.partyContent {
+    flex: 1;
+}
+
+.tags {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.3rem;
+}
+
+.tag,
+.tagHighlight {
+    font-size: 0.7rem;
+    padding: 0.2rem 0.5rem;
+    border-radius: 12px;
+    background-color: #e0e0e0;
+}
+
+.tagHighlight[data-gender='남자만'] {
+    background-color: #4fafff;
+    color: #fff;
+}
+
+.tagHighlight[data-gender='여자만'] {
+    background-color: #ff4f70;
+    color: #fff;
+}
+
+.tagHighlight[data-gender='상관없음'] {
+    background-color: #e0e0e0;
+    color: #000;
+}
+
+.partyTitle {
+    font-weight: bold;
+    margin-bottom: 0.3rem;
+}
+
+.partyMeta {
+    font-size: 0.85rem;
+    color: #555;
+    margin-bottom: 0.5rem;
+    display: flex;
+    gap: 0.5rem;
+}
+
+.partyStatus {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.avatars {
+    display: flex;
+    /*gap: -6px;*/
+    margin-right: 0.5rem;
+    width: 1.7rem;
+}
+
+.avatars img {
+    margin-left: -6px; /* 첫 번째 이미지 외에 오버랩 적용 */
+}
+
+.avatars img:first-child {
+    margin-left: 0; /* 첫 번째 이미지는 마진 없음 */
+}
+
+.slot {
+    font-size: 0.85rem;
+    color: #333;
+}
+/* end of section 2 */

--- a/src/pages/Party/Party.module.css
+++ b/src/pages/Party/Party.module.css
@@ -184,6 +184,7 @@
     gap: 1rem;
 }
 
+/* section 2 */
 .partyCard {
     display: flex;
     background-color: #f9f9f9;
@@ -272,6 +273,7 @@
     font-size: 0.85rem;
     color: #333;
 }
+/* end of section 2 */
 
 .modalReset {
     background: none;

--- a/src/pages/Party/PartyApply.js
+++ b/src/pages/Party/PartyApply.js
@@ -82,7 +82,7 @@ export default function PartyApply() {
                             onClick: () => {
                                 // 삭제 로직 실행
                                 setShowApplyModal(false);
-                                navigate('/party/matchid')
+                                navigate(`/party/matchid/${partyId}`);
                             }
                         }
                     ]}


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 실시간 인기 검색어 기능 제공
<img width="313" alt="image" src="https://github.com/user-attachments/assets/2039815a-325f-47e5-825d-f3b3f01310f7" />

- elasticsearch를 활용한 search-service msa와 연결하여, 실시간 인기 검색어 상위 5위를 노출
- 클릭 시 해당 검색어를 Query로 하여 검색 결과 페이지로 랜딩


### 2. 검색 결과 페이지 데이터 연동 및 해당 포스트로 이동 제공
<img width="313" alt="image" src="https://github.com/user-attachments/assets/73b610b0-6ced-4c9f-918c-15c83c76a79b" />

- 검색 Query에 대한 검색 결과 페이지 데이터 연동
- 클릭 시 해당 게시글로 이동하도록 설정


### 3. 메인 화면에 사용자 참여중인 직관팟 노출
<img width="313" alt="image" src="https://github.com/user-attachments/assets/78af575f-6643-46ba-a3ab-02bf19eeb052" />

- 내가 가입된 가장 최신의 직관팟을 노출하여 사용자에게 직관팟 현황 정보를 제공

---

## 🔗 관련 이슈
- closes #101 

---

## 💡 추가 사항
- 다음 Issue: 직관팟 후기 페이지 랜딩 및 후기 작성 연결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 메인 페이지에서 사용자가 승인한 파티 정보를 카드 형태로 표시하고, 클릭 시 파티 채팅방으로 이동할 수 있습니다.
    - 헤더 검색창에서 실시간 인기 검색어 드롭다운을 표시하고, 클릭 시 해당 키워드로 검색이 가능합니다.
- **버그 수정**
    - 커뮤니티 게시글 클릭 시 함수 파라미터 순서 변경으로 인한 네비게이션 오류를 수정했습니다.
    - 파티 신청 후 확인 버튼 클릭 시 파티 ID가 포함된 상세 페이지로 이동하도록 경로를 수정했습니다.
- **개선 사항**
    - 커뮤니티 검색 결과가 로컬스토리지가 아닌 백엔드 API에서 실시간으로 불러오도록 개선했습니다.
    - 커뮤니티 게시글 삭제 시 팀 정보를 포함한 API 경로로 요청이 전송됩니다.
    - 커뮤니티 게시글 목록이 로딩 중일 때 "로딩 중..." 메시지를 표시합니다.
- **스타일**
    - 메인 페이지 및 헤더의 신규 UI(파티 카드, 검색 드롭다운)에 대한 스타일이 추가되었습니다.
- **기타**
    - 불필요한 ESLint undefined 변수 검사 규칙을 비활성화했습니다.
    - 일부 CSS에 주석이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->