### PR TITLE
Cs 388 feat/직관팟 후기 작성 api 연결

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <link rel="icon" href="%PUBLIC_URL%/Logo/NewLogo_small.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -73,18 +73,22 @@ const GameCard = ({
                             ? styles.statusResult
                             : statusCode === "READY"
                                 ? styles.statusLive
-                                : statusCode === "BEFORE"
-                                    ? styles.statusBefore
-                                    : ""
+                                : statusCode === "STARTED"
+                                    ? styles.statusLive
+                                    : statusCode === "BEFORE"
+                                        ? styles.statusBefore
+                                        : ""
                     }
                 >
                   {statusCode === "RESULT"
                       ? "경기종료"
                       : statusCode === "READY"
-                          ? "LIVE!"
-                          : statusCode === "BEFORE"
-                              ? "경기전"
-                              : ""}
+                          ? "경기전"
+                          : statusCode === "STARTED"
+                              ? "LIVE!"
+                              : statusCode === "BEFORE"
+                                  ? "경기전"
+                                  : ""}
                 </span>
             </div>
 

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -67,11 +67,24 @@ const GameCard = ({
             <div className={styles.infoBlock}>
                 <span className={styles.mainTime}>{mainTime}</span>
                 <span className={styles.stadium}>{stadium}</span>
-                <span className={styles.status}>
-                  {statusCode === "RESULT" ? "경기종료" :
-                   statusCode === "STARTED" ? "경기중" :
-                   statusCode === "BEFORE" ? "경기전" :
-                   ""}
+                <span
+                    className={
+                        statusCode === "RESULT"
+                            ? styles.statusResult
+                            : statusCode === "READY"
+                                ? styles.statusLive
+                                : statusCode === "BEFORE"
+                                    ? styles.statusBefore
+                                    : ""
+                    }
+                >
+                  {statusCode === "RESULT"
+                      ? "경기종료"
+                      : statusCode === "READY"
+                          ? "LIVE!"
+                          : statusCode === "BEFORE"
+                              ? "경기전"
+                              : ""}
                 </span>
             </div>
 
@@ -90,16 +103,16 @@ const GameCard = ({
 export default GameCard;
 
 GameCard.propTypes = {
-        matchId: PropTypes.number,
-        time: PropTypes.string.isRequired,
-        homeTeam: PropTypes.string.isRequired,
-        awayTeam: PropTypes.string.isRequired,
-        stadium: PropTypes.string.isRequired,
-        mainTime: PropTypes.string.isRequired,
-        homeLogo: PropTypes.string.isRequired,
-        awayLogo: PropTypes.string.isRequired,
-        homeTeamScore: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        awayTeamScore: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-        statusCode: PropTypes.oneOf(['RESULT', 'STARTED', 'BEFORE']).isRequired,
-        gameId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
-    };
+    matchId: PropTypes.number,
+    time: PropTypes.string.isRequired,
+    homeTeam: PropTypes.string.isRequired,
+    awayTeam: PropTypes.string.isRequired,
+    stadium: PropTypes.string.isRequired,
+    mainTime: PropTypes.string.isRequired,
+    homeLogo: PropTypes.string.isRequired,
+    awayLogo: PropTypes.string.isRequired,
+    homeTeamScore: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    awayTeamScore: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    statusCode: PropTypes.oneOf(['RESULT', 'STARTED', 'BEFORE']).isRequired,
+    gameId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+};

--- a/src/components/GameCard/GameCard.js
+++ b/src/components/GameCard/GameCard.js
@@ -117,6 +117,6 @@ GameCard.propTypes = {
     awayLogo: PropTypes.string.isRequired,
     homeTeamScore: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     awayTeamScore: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-    statusCode: PropTypes.oneOf(['RESULT', 'STARTED', 'BEFORE']).isRequired,
+    statusCode: PropTypes.oneOf(['RESULT', 'STARTED', 'BEFORE', 'READY']).isRequired,
     gameId: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
 };

--- a/src/components/GameCard/GameCard.module.css
+++ b/src/components/GameCard/GameCard.module.css
@@ -53,11 +53,29 @@
     padding-bottom: 0.5rem;
 }
 
-.status {
+.statusLive {
     font-size: 0.875rem;
     color: #ffffff;
     font-weight: 600;
     background-color: #ff4f4f;
+    padding: 0.3rem 0.5rem;
+    border-radius: 1.5rem;
+}
+
+.statusResult {
+    font-size: 0.875rem;
+    color: #ffffff;
+    font-weight: 600;
+    background-color: #6b7280;
+    padding: 0.3rem 0.5rem;
+    border-radius: 1.5rem;
+}
+
+.statusBefore {
+    font-size: 0.875rem;
+    color: #ffffff;
+    font-weight: 600;
+    background-color: #3b82f6;
     padding: 0.3rem 0.5rem;
     border-radius: 1.5rem;
 }

--- a/src/components/Modal/ReviewSelectModal/ReviewSelectModal.js
+++ b/src/components/Modal/ReviewSelectModal/ReviewSelectModal.js
@@ -7,7 +7,6 @@ const ReviewSelectModal = ({title, selectedMessage, onSelect, onClose}) => {
     const [open, setOpen] = useState(false);
 
     const PRESET_MESSAGES = [
-        '답장이 빨라요.',
         '시간 약속을 잘 지켜요.',
         '경기 직관이 열정적이에요.',
         '상대방에 대한 배려심이 깊어요.',

--- a/src/pages/Main/ScheduleSection.js
+++ b/src/pages/Main/ScheduleSection.js
@@ -28,18 +28,18 @@ export default function ScheduleSection({ schedule }) {
         {/* Away 팀 */}
         <div className={styles.teamColumn}>
           <div className={styles.name}>{away}</div>
-          <div className={styles.player}>오승환</div>
+          {/*<div className={styles.player}>오승환</div>*/}
         </div>
         <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo/${teamLogoMap[away] || 'emblem_default.png'}`} alt={away} className={styles.logo} />
-        <div className={styles.score}>{score[1]}</div>
+        <div className={styles.score}>{score[0]}</div>
 
         <div className={styles.status}>{status}</div>
 
-        <div className={styles.score}>{score[0]}</div>
+        <div className={styles.score}>{score[1]}</div>
         <img src={`${process.env.PUBLIC_URL}/Logo/TeamLogo/${teamLogoMap[home] || 'emblem_default.png'}`} alt={home} className={styles.logo} />
         <div className={styles.teamColumn}>
           <div className={styles.name}>{home}</div>
-          <div className={styles.player}>우강훈</div>
+          {/*<div className={styles.player}>우강훈</div>*/}
         </div>
       </div>
       </div>

--- a/src/pages/Party/Party.js
+++ b/src/pages/Party/Party.js
@@ -325,32 +325,6 @@ const Party = () => {
                     {activeTab === 1 && (
                         <div className={styles.approvalSection}>
                             <div className={styles.myStatusList}>
-                                {/* 직관팟 후기 작성 테스트를 위한 임시 dummydata 카드 */}
-                                <div className={styles.myStatusCard}>
-                                  <div className={styles.myStatusCardContent}>
-                                    <div className={styles.myStatusTagRow}>
-                                      <span className={styles.tag}>10대</span>
-                                      <span className={styles.tag}>20대</span>
-                                      <span className={styles.tagHighlight}>남자만</span>
-                                    </div>
-                                    <div className={styles.myStatusTitle}>
-                                      <strong>더미 직관팟 제목</strong>
-                                    </div>
-                                    <div className={styles.myStatusMeta}>
-                                      <span>직관팟후기</span>
-                                      <span>20대</span>
-                                      <span>남성</span>
-                                    </div>
-                                    <div className={styles.myStatusButtons}>
-                                      <button className={styles.statusCancel} onClick={() => navigate(`/review/party/${1}`)}>후기 작성</button>
-                                    </div>
-                                  </div>
-                                  <img
-                                    src={`${process.env.PUBLIC_URL}/Logo/jikgwanprofile.png`}
-                                    alt="더미 썸네일"
-                                    className={styles.thumbnailImg}
-                                  />
-                                </div>
                                 {myApplications.map((party, idx) => {
                                     const statusKey = mapStatusToKey(party.partyJoinRequestStatus);
                                     return (

--- a/src/pages/Party/Party.js
+++ b/src/pages/Party/Party.js
@@ -228,7 +228,7 @@ const Party = () => {
                                       <span className={styles.matchBadge}>
                                         {matchDetail.status_code === 'RESULT'
                                             ? '경기종료'
-                                            : matchDetail.status_code === 'STARTED'
+                                            : (matchDetail.status_code === 'BEFORE' || matchDetail.status_code === 'READY')
                                                 ? '경기중'
                                                 : '경기전'}
                                       </span>

--- a/src/pages/Party/Party.js
+++ b/src/pages/Party/Party.js
@@ -325,6 +325,32 @@ const Party = () => {
                     {activeTab === 1 && (
                         <div className={styles.approvalSection}>
                             <div className={styles.myStatusList}>
+                                {/* 직관팟 후기 작성 테스트를 위한 임시 dummydata 카드 */}
+                                <div className={styles.myStatusCard}>
+                                  <div className={styles.myStatusCardContent}>
+                                    <div className={styles.myStatusTagRow}>
+                                      <span className={styles.tag}>10대</span>
+                                      <span className={styles.tag}>20대</span>
+                                      <span className={styles.tagHighlight}>남자만</span>
+                                    </div>
+                                    <div className={styles.myStatusTitle}>
+                                      <strong>더미 직관팟 제목</strong>
+                                    </div>
+                                    <div className={styles.myStatusMeta}>
+                                      <span>직관팟후기</span>
+                                      <span>20대</span>
+                                      <span>남성</span>
+                                    </div>
+                                    <div className={styles.myStatusButtons}>
+                                      <button className={styles.statusCancel} onClick={() => navigate(`/review/party/${1}`)}>후기 작성</button>
+                                    </div>
+                                  </div>
+                                  <img
+                                    src={`${process.env.PUBLIC_URL}/Logo/jikgwanprofile.png`}
+                                    alt="더미 썸네일"
+                                    className={styles.thumbnailImg}
+                                  />
+                                </div>
                                 {myApplications.map((party, idx) => {
                                     const statusKey = mapStatusToKey(party.partyJoinRequestStatus);
                                     return (
@@ -378,6 +404,13 @@ const Party = () => {
                                                                         onClick={() => onEnterChat(party.partyId)}
                                                                     >
                                                                         채팅방 입장!
+                                                                    </button>
+                                                                    <button
+                                                                        className={styles.statusApproved}
+                                                                        onClick={() => {
+                                                                            navigate(`/review/party/${party.partyId}`)}}
+                                                                    >
+                                                                        후기 작성
                                                                     </button>
                                                                     <span className={styles.newChatCount}>1</span>
                                                                 </>

--- a/src/pages/Party/Party.js
+++ b/src/pages/Party/Party.js
@@ -228,9 +228,9 @@ const Party = () => {
                                       <span className={styles.matchBadge}>
                                         {matchDetail.status_code === 'RESULT'
                                             ? '경기종료'
-                                            : (matchDetail.status_code === 'BEFORE' || matchDetail.status_code === 'READY')
-                                                ? '경기중'
-                                                : '경기전'}
+                                            : matchDetail.status_code === 'READY' ? '경기중'
+                                                : matchDetail.status_code === 'BEFORE' ? '경기전'
+                                                    : matchDetail.status_code === 'STARTED' ? '경기중' : ""}
                                       </span>
                                         </div>
                                     </div>

--- a/src/pages/Party/Party.js
+++ b/src/pages/Party/Party.js
@@ -226,11 +226,15 @@ const Party = () => {
                                         </div>
                                         <div className={styles.matchBadgeArea}>
                                       <span className={styles.matchBadge}>
-                                        {matchDetail.status_code === 'RESULT'
-                                            ? '경기종료'
-                                            : matchDetail.status_code === 'READY' ? '경기중'
-                                                : matchDetail.status_code === 'BEFORE' ? '경기전'
-                                                    : matchDetail.status_code === 'STARTED' ? '경기중' : ""}
+                                        {matchDetail.statusCode === "RESULT"
+                                            ? "경기종료"
+                                            : matchDetail.statusCode === "READY"
+                                                ? "경기전"
+                                                : matchDetail.statusCode === "STARTED"
+                                                    ? "LIVE!"
+                                                    : matchDetail.statusCode === "BEFORE"
+                                                        ? "경기전"
+                                                        : ""}
                                       </span>
                                         </div>
                                     </div>

--- a/src/pages/Party/ReviewParty/ReviewParty.js
+++ b/src/pages/Party/ReviewParty/ReviewParty.js
@@ -1,12 +1,16 @@
 // 직관팟 기간 만료 시 직관팟 참가자들의 후기를 작성하는 페이지
-import React, {useState} from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './ReviewParty.module.css';
 import Modal from '../../../components/Modal/Modal';
 import ReviewSelectModal from '../../../components/Modal/ReviewSelectModal/ReviewSelectModal';
-import {useNavigate} from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
+import axios from 'axios';
 
 const ReviewParty = () => {
     const navigate = useNavigate();
+    const { partyId } = useParams();
+    // const [reviewData, setReviewData] = useState([]);
+
     const [reviewData, setReviewData] = useState([
         {name: 'ZSJ', liked: null, message: ''},
         {name: '네모', liked: null, message: ''},
@@ -14,6 +18,30 @@ const ReviewParty = () => {
         {name: '20년째보살팬', liked: null, message: ''},
         {name: '언제나한화생각', liked: null, message: ''}
     ]);
+    // useEffect(() => {
+    //     if (partyId) {
+    //         const fetchAppliedUsers = async () => {
+    //             try {
+    //                 const res = await axios.get(
+    //                     `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${partyId}/approved-applicants`,
+    //                     { withCredentials: true }
+    //                 );
+    //                 // res.data is an array of PartyAppliedUserResponse
+    //                 const users = res.data.map(user => ({
+    //                     userId: user.userId,
+    //                     name: user.name,
+    //                     liked: null,
+    //                     message: ''
+    //                 }));
+    //                 setReviewData(users);
+    //             } catch (err) {
+    //                 console.error('Failed to fetch applied users:', err);
+    //                 setReviewData([]);
+    //             }
+    //         };
+    //         fetchAppliedUsers();
+    //     }
+    // }, [partyId]);
     const [modalOpen, setModalOpen] = useState(false);
     const [showReviewRegisterModal, setShowReviewRegisterModal] = useState(false);
     const handleSubmitReview = () => {

--- a/src/pages/Party/ReviewParty/ReviewParty.js
+++ b/src/pages/Party/ReviewParty/ReviewParty.js
@@ -10,6 +10,7 @@ const ReviewParty = () => {
     const navigate = useNavigate();
     const { partyId } = useParams();
     const [reviewData, setReviewData] = useState([]);
+    const [showErrorModal, setShowErrorModal] = useState(false);
 
     useEffect(() => {
         if (partyId) {
@@ -29,6 +30,7 @@ const ReviewParty = () => {
                     setReviewData(users);
                 } catch (err) {
                     console.error('Failed to fetch participants:', err);
+                    setShowErrorModal(true);
                     setReviewData([]);
                 }
             };
@@ -64,7 +66,7 @@ const ReviewParty = () => {
             );
             setShowReviewRegisterModal(true);
         } catch (err) {
-            console.error('Failed to send reviews:', err);
+            setShowErrorModal(true);
         }
     };
     const [selectedMemberIdx, setSelectedMemberIdx] = useState(null);
@@ -136,6 +138,20 @@ const ReviewParty = () => {
                             navigate('/schedule');
                         }
                     }]}
+                />
+            )}
+            {showErrorModal && (
+                <Modal
+                    title="에러"
+                    message="후기 전송 중 오류가 발생했습니다."
+                    buttons={[
+                        {
+                            label: '확인',
+                            onClick: () => {
+                                setShowErrorModal(false);
+                            }
+                        }
+                    ]}
                 />
             )}
         </div>

--- a/src/pages/Party/ReviewParty/ReviewParty.js
+++ b/src/pages/Party/ReviewParty/ReviewParty.js
@@ -9,43 +9,63 @@ import axios from 'axios';
 const ReviewParty = () => {
     const navigate = useNavigate();
     const { partyId } = useParams();
-    // const [reviewData, setReviewData] = useState([]);
+    const [reviewData, setReviewData] = useState([]);
 
-    const [reviewData, setReviewData] = useState([
-        {name: 'ZSJ', liked: null, message: ''},
-        {name: '네모', liked: null, message: ''},
-        {name: '인기스타김도영', liked: null, message: ''},
-        {name: '20년째보살팬', liked: null, message: ''},
-        {name: '언제나한화생각', liked: null, message: ''}
-    ]);
-    // useEffect(() => {
-    //     if (partyId) {
-    //         const fetchAppliedUsers = async () => {
-    //             try {
-    //                 const res = await axios.get(
-    //                     `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${partyId}/approved-applicants`,
-    //                     { withCredentials: true }
-    //                 );
-    //                 // res.data is an array of PartyAppliedUserResponse
-    //                 const users = res.data.map(user => ({
-    //                     userId: user.userId,
-    //                     name: user.name,
-    //                     liked: null,
-    //                     message: ''
-    //                 }));
-    //                 setReviewData(users);
-    //             } catch (err) {
-    //                 console.error('Failed to fetch applied users:', err);
-    //                 setReviewData([]);
-    //             }
-    //         };
-    //         fetchAppliedUsers();
-    //     }
-    // }, [partyId]);
+    useEffect(() => {
+        if (partyId) {
+            const fetchParticipants = async () => {
+                try {
+                    const res = await axios.get(
+                        `${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${partyId}/participants`,
+                        { withCredentials: true }
+                    );
+                    // res.data is an array of PartyParticipantsInfoResponse
+                    const users = res.data.map(user => ({
+                        userId: user.userId,
+                        name: user.name,
+                        liked: null,
+                        message: ''
+                    }));
+                    setReviewData(users);
+                } catch (err) {
+                    console.error('Failed to fetch participants:', err);
+                    setReviewData([]);
+                }
+            };
+            fetchParticipants();
+        }
+    }, [partyId]);
     const [modalOpen, setModalOpen] = useState(false);
     const [showReviewRegisterModal, setShowReviewRegisterModal] = useState(false);
-    const handleSubmitReview = () => {
-        setShowReviewRegisterModal(true);
+    const handleSubmitReview = async () => {
+        const messageToTagId = {
+            '시간 약속을 잘 지켜요.': 3,
+            '경기 직관이 열정적이에요.': 4,
+            '상대방에 대한 배려심이 깊어요.': 5,
+            '어색한 분위기를 잘 풀어요.': 6,
+            '야구 경기에 박식해요.': 7
+        };
+        const payload = reviewData
+            .filter(member => member.liked === true || member.liked === false)
+            .map(member => {
+                if (member.liked === true) {
+                    const tagId = member.message ? (messageToTagId[member.message] || 2) : 2;
+                    return { userId: member.userId, tagId, positive: true };
+                } else if (member.liked === false) {
+                    return { userId: member.userId, tagId: 2, positive: false };
+                }
+                // If neither liked nor disliked, skip (should not occur due to filter)
+            });
+        try {
+            await axios.post(
+                `${process.env.REACT_APP_LOCAL_BACKEND_URI}/users/reviews`,
+                payload,
+                { withCredentials: true }
+            );
+            setShowReviewRegisterModal(true);
+        } catch (err) {
+            console.error('Failed to send reviews:', err);
+        }
     };
     const [selectedMemberIdx, setSelectedMemberIdx] = useState(null);
 
@@ -96,7 +116,7 @@ const ReviewParty = () => {
                     </div>
                 ))}
             </div>
-            <button className={styles.nextBtn} onClick={handleSubmitReview}>다음</button>
+            <button className={styles.nextBtn} onClick={handleSubmitReview}>후기 전송!</button>
 
             {modalOpen && (
                 <ReviewSelectModal
@@ -110,10 +130,12 @@ const ReviewParty = () => {
                 <Modal
                     title="후기 작성 완료!"
                     message="소중한 후기가 전달되었어요!"
-                    onClose={() => {
-                        setShowReviewRegisterModal(false);
-                        navigate('/schedule');
-                    }}
+                    buttons={[{
+                        label: '확인', onClick: () => {
+                            setShowReviewRegisterModal(false);
+                            navigate('/schedule');
+                        }
+                    }]}
                 />
             )}
         </div>

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -338,7 +338,7 @@ useEffect(() => {
                                                     </div>
                                                 </div>
                                                 <div className={styles.reviewSummary}>
-                                                    <p>후기 태그 상위 3개</p>
+                                                    <p>이 회원님께서는...</p>
                                                     <div className={styles.reviewTagContainer}>
                                                         {tagSummary.topTags.length > 0 ? (
                                                             tagSummary.topTags.map((tagName, idx) => (

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -317,8 +317,8 @@ useEffect(() => {
                                                             datasets: [
                                                                 {
                                                                     data: [
-                                                                        profile.userScore,
-                                                                        1 - profile.userScore
+                                                                        profile.userScore || 0,
+                                                                        1 - (profile.userScore || 0)
                                                                     ],
                                                                     backgroundColor: ['#f66', '#f2f2f2'],
                                                                     borderWidth: 0
@@ -334,7 +334,7 @@ useEffect(() => {
                                                         }}
                                                     />
                                                     <div className={styles.accuracyNumberOverlay}>
-                                                        {profile.userScore.toFixed(3)}
+                                                        {(profile.userScore || 0).toFixed(3)}
                                                     </div>
                                                 </div>
                                                 <div className={styles.reviewSummary}>

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -156,7 +156,24 @@ useEffect(() => {
         navigate('/login');
     };
 
-    const accuracyValue = 9.3; // TODO: 해당 값은 후기 타율 데이터를 받아와 구현
+    // 후기 태그 요약 정보 state 및 fetch
+    const [tagSummary, setTagSummary] = useState(null);
+    useEffect(() => {
+        if (!isMine && userId) {
+            const fetchTagSummary = async () => {
+                try {
+                    const res = await axios.get(
+                        `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/${userId}/tags/summary`,
+                        { withCredentials: true }
+                    );
+                    setTagSummary(res.data);
+                } catch (err) {
+                    setTagSummary(null);
+                }
+            };
+            fetchTagSummary();
+        }
+    }, [isMine, userId]);
 
     const tileContent = ({date, view}) => {
         if (view === 'month') {
@@ -288,40 +305,58 @@ useEffect(() => {
                             </>
                         ) : (
                             <>
-                                <section className={styles.accuracySection}>
-                                    <h2>직관 타율</h2>
-                                    <div className={styles.accuracyChartWrapper}>
-                                        <div className={styles.accuracyCircle}>
-                                            <Doughnut
-                                                data={{
-                                                    labels: ['타율', '빈 공간'],
-                                                    datasets: [
-                                                        {
-                                                            data: [accuracyValue, 100 - accuracyValue],
-                                                            backgroundColor: ['#f66', '#f2f2f2'],
-                                                            borderWidth: 0
-                                                        }
-                                                    ]
-                                                }}
-                                                options={{
-                                                    cutout: '70%',
-                                                    plugins: {
-                                                        legend: {display: false},
-                                                        tooltip: {enabled: false}
-                                                    }
-                                                }}
-                                            />
-                                            <div
-                                                className={styles.accuracyNumberOverlay}>{(accuracyValue / 100).toFixed(3)}</div>
-                                        </div>
-                                        <div className={styles.reviewSummary}>
-                                            <p>100명 중 42명이 직관팟에 만족했어요.</p>
-                                            <div className={styles.reviewTag}>답장이 빨라요.</div>
-                                            <div className={styles.reviewTag}>시간 약속을 잘 지켜요.</div>
-                                            <div className={styles.reviewTag}>경기 직관이 열정적이에요.</div>
-                                        </div>
-                                    </div>
-                                </section>
+                                {!isMine && (
+                                    <section className={styles.accuracySection}>
+                                        <h2>직관 타율</h2>
+                                        {tagSummary ? (
+                                            <div className={styles.accuracyChartWrapper}>
+                                                <div className={styles.accuracyCircle}>
+                                                    <Doughnut
+                                                        data={{
+                                                            labels: ['타율', '빈 공간'],
+                                                            datasets: [
+                                                                {
+                                                                    data: [
+                                                                        profile.userScore,
+                                                                        1 - profile.userScore
+                                                                    ],
+                                                                    backgroundColor: ['#f66', '#f2f2f2'],
+                                                                    borderWidth: 0
+                                                                }
+                                                            ]
+                                                        }}
+                                                        options={{
+                                                            cutout: '70%',
+                                                            plugins: {
+                                                                legend: { display: false },
+                                                                tooltip: { enabled: false }
+                                                            }
+                                                        }}
+                                                    />
+                                                    <div className={styles.accuracyNumberOverlay}>
+                                                        {profile.userScore.toFixed(3)}
+                                                    </div>
+                                                </div>
+                                                <div className={styles.reviewSummary}>
+                                                    <p>후기 태그 상위 3개</p>
+                                                    <div className={styles.reviewTagContainer}>
+                                                        {tagSummary.topTags.length > 0 ? (
+                                                            tagSummary.topTags.map((tagName, idx) => (
+                                                                <span key={idx} className={styles.reviewTag}>
+                                                                    {tagName}
+                                                                </span>
+                                                            ))
+                                                        ) : (
+                                                            <span className={styles.noTagsText}>태그가 없습니다.</span>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            <p>후기 정보를 불러오는 중입니다...</p>
+                                        )}
+                                    </section>
+                                )}
 
                                 <section className={styles.journalSection}>
                                     <div className={styles.journalHeader}>

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -225,6 +225,19 @@
   font-size: 0.85rem;
   color: #333;
 }
+.reviewSummary p {
+  font-size: 1.2rem;
+  font-weight: bold;
+  border-bottom: #F2F2F2 1px solid;
+  margin-bottom: 0.5rem;
+}
+
+.reviewTagContainer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
 
 .reviewTag {
   background-color: #f2f2f2;

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -86,7 +86,7 @@ function AppRouter() {
                     <Route index element={<Chatting/>}/>
                 </Route>
                 {/* 직관팟 후기 페이지 */}
-                <Route path="/review/party/:partyid" element={<MobileView/>}>
+                <Route path="/review/party/:partyId" element={<MobileView/>}>
                     <Route index element={<ReviewParty/>}/>
                 </Route>
                 {/* 프로필 & 직관일지 */}

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -57,17 +57,12 @@ function AppRouter() {
                 <Route path="/search" element={<MobileView />}>
                     <Route index element={<SearchResultPage />} />
                 </Route>
-                {/* 서브메뉴 표시 탭 -> 라우트에는 필요 없어서 주석 처리함 */}
-                {/*<Route path="/schedule/tab" element={<MobileView/>}>*/}
-                {/*    <Route index element={<TabNav/>}/>*/}
-                {/*</Route>*/}
                 {/* 경기 정보 */}
                 <Route path="/schedule/:gameId" element={<MobileView/>}>
                     <Route index element={<MatchInfo/>}/>
                 </Route>
                 {/* 직관팟 목록 */}
                 <Route path="/party/:gameId" element={<MobileView/>}>
-                    {/*나중에 path를 /party/{partyid}로 수정 예정*/}
                     <Route index element={<Party/>}/>
                 </Route>
                 {/* 직관팟 상세 */}
@@ -91,12 +86,9 @@ function AppRouter() {
                     <Route index element={<Chatting/>}/>
                 </Route>
                 {/* 직관팟 후기 페이지 */}
-                <Route path="/review/party/partyid" element={<MobileView/>}>
+                <Route path="/review/party/:partyid" element={<MobileView/>}>
                     <Route index element={<ReviewParty/>}/>
                 </Route>
-                {/*<Route path="/schedule" element={<MobileView/>}>*/}
-                {/*    <Route index element={<LeagueSchedule />} />*/}
-                {/*</Route>*/}
                 {/* 프로필 & 직관일지 */}
                 {/* 프로필 메인 & 타 사용자 프로필 */}
                 <Route path="/profile/:userId" element={<MobileView/>}>


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 상대방 프로필 확인
![image](https://github.com/user-attachments/assets/5442c848-8c29-4003-9a75-581f3d908f8d)

- 실제 직관 타율(후기 온도)와 태그 데이터 적용

### 2. 직관 후기 작성
![image](https://github.com/user-attachments/assets/dbf5eb7a-da91-4d4d-a5a3-a07a4264faf8)

- 긍정 리뷰 선택 시 5개 태그 중 하나를 선택하여 직관팟 참여자에게 전송

---

## 🔗 관련 이슈
- closes #103 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 경기카드와 파티 페이지에서 경기 상태 뱃지에 "READY" 상태가 추가되고, 각 상태별로 구분된 스타일과 텍스트가 적용되었습니다.
  - 파티 신청 내역에서 "후기 작성" 버튼이 추가되어, 승인된 파티에 대해 바로 후기 작성이 가능합니다.
  - 프로필 페이지에서 상대방의 리뷰 태그 요약 정보를 백엔드에서 불러와 도넛 차트와 태그 리스트로 시각화하여 보여줍니다.
  - 리뷰 작성 페이지에서 참가자 정보를 API로 동적으로 불러오고, 후기 전송 시 백엔드로 데이터가 전송됩니다.

- **버그 수정**
  - 스케줄 섹션에서 원정팀과 홈팀의 점수 표기가 올바르게 교체되었습니다.

- **스타일**
  - 경기 상태 뱃지 및 프로필의 리뷰 요약/태그 영역에 새로운 CSS 스타일이 적용되어 가독성과 시각적 구분이 향상되었습니다.

- **보안**
  - 모든 리소스 요청이 HTTPS로 자동 업그레이드되도록 Content Security Policy 메타 태그가 추가되었습니다.

- **기타**
  - 리뷰 선택 모달의 기본 문구 중 "답장이 빨라요."가 제거되었습니다.
  - 리뷰 파티 경로가 동적 파라미터(:partyId)로 수정되어 각 파티별로 접근이 가능합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->