### PR TITLE
Cs 411 fix/localhost 하드코딩 제거

### DIFF
--- a/src/components/TeamTabNav/TeamTabNav.module.css
+++ b/src/components/TeamTabNav/TeamTabNav.module.css
@@ -14,7 +14,7 @@
   display: flex;
   justify-content: space-between;
   position: relative;
-  width: 350px;
+  width: 450px;
   margin: 0 auto;
   padding-bottom: 6px;
   border-bottom: 1px solid #ccc;

--- a/src/components/TeamTabNav/TeamTabNav.module.css
+++ b/src/components/TeamTabNav/TeamTabNav.module.css
@@ -14,7 +14,7 @@
   display: flex;
   justify-content: space-between;
   position: relative;
-  width: 450px;
+  width: 100%;
   margin: 0 auto;
   padding-bottom: 6px;
   border-bottom: 1px solid #ccc;

--- a/src/pages/Party/PartyApply.js
+++ b/src/pages/Party/PartyApply.js
@@ -16,7 +16,7 @@ export default function PartyApply() {
     const [showApplyModal, setShowApplyModal] = useState(false);
     const handleSubmit = async () => {
         try {
-            await axios.post(`http://localhost:8081/party/${partyId}/apply`, {
+            await axios.post(`${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${partyId}/apply`, {
                 requireMessage: message
             }, {
                 withCredentials: true

--- a/src/pages/Party/PartyMake.js
+++ b/src/pages/Party/PartyMake.js
@@ -129,14 +129,14 @@ const PartyMake = () => {
 
         try {
             if (isEditMode) {
-                await axios.put(`http://localhost:8081/party/${partyId}`, payload, {
+                await axios.put(`${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party/${partyId}`, payload, {
                     withCredentials: true,
                     headers: {'Content-Type': 'application/json'},
                 });
                 setModalMessage('직관팟이 성공적으로 수정되었습니다!');
                 setModalVisible(true);
             } else {
-                const response = await axios.post('http://localhost:8081/party', payload, {
+                const response = await axios.post(`${process.env.REACT_APP_LOCAL_BACKEND_TWP_URI}/party`, payload, {
                     withCredentials: true,
                     headers: {'Content-Type': 'application/json'},
                 });


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
1. TeamTabNav의 width를 확대했습니다.
2. 남아있던 localhost 하드코딩 경로를 대체했습니다.

---

## 🔗 관련 이슈
- closes #108 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - 팀 탭 내비게이션의 탭 너비가 고정 350px에서 화면 전체 폭에 맞게 100%로 변경되었습니다.

- **Chores**
  - 파티 신청 및 생성/수정 시 백엔드 요청 URL이 하드코딩에서 환경 변수 기반으로 변경되어, 더 유연한 환경 설정이 가능해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->