### PR TITLE
Cs 417 fix/직관일지 목록 자체 pagination

### DIFF
--- a/src/pages/InitialProfile/SetProfile.js
+++ b/src/pages/InitialProfile/SetProfile.js
@@ -66,15 +66,13 @@ const SetProfile = () => {
                 }
 
                 const presignedRes = await axios.post(
-                    `${process.env.REACT_APP_LOCAL_BACKEND_URI}/presigned-url`,
+                    `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/presigned-url`,
                     { imageFileName: fileName },
                     { headers: { 'Content-Type': 'application/json' }, withCredentials: true }
                 );
 
-                await fetch(presignedRes.data.presignedUrl, {
-                    method: 'PUT',
-                    body: fileBlob,
-                    headers: { 'Content-Type': 'image/png' },
+                await axios.put(presignedRes.data.presignedUrl, fileBlob, {
+                    headers: { 'Content-Type': 'image/png' }
                 });
 
                 thumbnailURL = `${process.env.REACT_APP_PRESIGNED_URI}/${fileName}`;
@@ -93,7 +91,7 @@ const SetProfile = () => {
 
         try {
             await axios.post(
-                `${process.env.REACT_APP_LOCAL_BACKEND_URI}/register`,
+                `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/register`,
                 payload,
                 {
                     headers: { 'Content-Type': 'application/json' },

--- a/src/pages/InitialProfile/SetProfile.js
+++ b/src/pages/InitialProfile/SetProfile.js
@@ -71,8 +71,20 @@ const SetProfile = () => {
                     { headers: { 'Content-Type': 'application/json' }, withCredentials: true }
                 );
 
-                await axios.put(presignedRes.data.presignedUrl, fileBlob, {
-                    headers: { 'Content-Type': 'image/png' }
+                await new Promise((resolve, reject) => {
+                    fetch(presignedRes.data.presignedUrl, {
+                        method: 'PUT',
+                        body: fileBlob,
+                        headers: {
+                            // 'Content-Type': 'image/png',
+                            // 다른 헤더 추가하지 마세요!
+                        },
+                    })
+                    .then(response => {
+                        if (!response.ok) throw new Error("이미지 업로드 실패");
+                        resolve();
+                    })
+                    .catch(reject);
                 });
 
                 thumbnailURL = `${process.env.REACT_APP_PRESIGNED_URI}/${fileName}`;

--- a/src/pages/LiveMatchDiary/DiaryList.js
+++ b/src/pages/LiveMatchDiary/DiaryList.js
@@ -34,26 +34,15 @@ const DiaryList = () => {
             setError(null);
             try {
                 const response = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/live-match-diary/my`, {
-                    params: {
-                        page: page - 1,
-                        size: 10
-                    },
                     withCredentials: true, // 필요시 쿠키 인증
                 });
 
                 let entriesArray;
-                let tp;
-                if (response.data.content !== undefined && response.data.totalPages !== undefined) {
-                  // Backend returned a Page object
-                  entriesArray = response.data.content;
-                  tp = response.data.totalPages;
-                } else if (Array.isArray(response.data)) {
+                if (Array.isArray(response.data)) {
                   // Backend returned a simple list
                   entriesArray = response.data;
-                  tp = 1; // default to single page (all items)
                 } else {
                   entriesArray = [];
-                  tp = 1;
                 }
                 const data = entriesArray.map((entry) => {
                     const teamData = teamInfoMapCommunity.find(team => team.teamId === entry.TeamName);
@@ -69,7 +58,7 @@ const DiaryList = () => {
                     };
                 });
                 setDiaries(data);
-                setTotalPages(tp);
+                setTotalPages(Math.ceil(data.length / 8));
 
             } catch (error) {
                 console.error('직관일지 목록 불러오기 실패:', error);
@@ -91,7 +80,7 @@ const DiaryList = () => {
         navigate(`/profile/${userId}`);
     }
 
-    const pagedDiaries = diaries;
+    const pagedDiaries = diaries.slice((page - 1) * 8, page * 8);
 
     // Navigate to diary detail page
     const handleClickDiary = (id) => {
@@ -126,9 +115,11 @@ const DiaryList = () => {
                                      className={styles.thumbnail}/>
                             ) : null}
                             <div className={styles.entryContent}>
-                                <span className={styles.entryTitle}>{entry.title}</span>
+                                <div>
+                                    <span className={styles.entryTitle}>{entry.title}</span>
+                                    {entry.teamLogo && <img src={entry.teamLogo} alt="logo" className={styles.teamLogo}/>}
+                                </div>
                                 <span className={styles.entryDate}>{entry.date}</span>
-                                {entry.teamLogo && <img src={entry.teamLogo} alt="logo" className={styles.teamLogo}/>}
                             </div>
                         </div>
                     ))}

--- a/src/pages/LiveMatchDiary/DiaryList.module.css
+++ b/src/pages/LiveMatchDiary/DiaryList.module.css
@@ -40,8 +40,10 @@
 
 .entryContent {
   display: flex;
-  flex-direction: column;
-  gap: 4px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
 }
 
 .entryTitle {
@@ -51,6 +53,7 @@
 .entryDate {
   font-size: 0.9rem;
   color: #555;
+  margin-left: auto;
 }
 
 .teamLogo {
@@ -61,7 +64,7 @@
 .paginationWrapper {
   display: flex;
   justify-content: center;
-  margin-top: 1.5rem;
+  margin-top: 1rem;
 }
 
 .casterbotButton {

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -82,7 +82,7 @@ const Profile = () => {
                     return {
                         id: entry.postId,
                         title: entry.title,
-                        date: entry.twpDate || entry.date,
+                        date: entry.date,
                         image: entry.thumbnail || null,
                         team: teamData?.name || '',
                         teamLogo: teamData?.logo || `${process.env.PUBLIC_URL}/exImage.png`,
@@ -318,11 +318,7 @@ useEffect(() => {
                                                 )}
                                                 <span className={styles.entryTitle}>{entry.title}</span>
                                                 <span className={styles.entryDate}>
-                                                    {new Date(entry.date).toLocaleDateString('ko-KR', {
-                                                        year: 'numeric',
-                                                        month: '2-digit',
-                                                        day: '2-digit'
-                                                    })}
+                                                    {entry.date?.replace(/-/g, '.')}
                                                 </span>
                                             </li>
                                         ))}

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -51,6 +51,8 @@ const journalEntries = [
 const Profile = () => {
     // 최근 직관일지 state
     const [recentDiaries, setRecentDiaries] = useState([]);
+    // 최근 커뮤니티 게시글 state
+    const [recentPosts, setRecentPosts] = useState([]);
     // 최근 직관일지 fetch
 
     // const [searchParams] = useSearchParams();
@@ -141,6 +143,24 @@ useEffect(() => {
     };
 
     fetchProfile();
+}, [userId]);
+
+// 최근 커뮤니티 게시글 fetch
+useEffect(() => {
+    const fetchRecentPosts = async () => {
+        if (!userId) return;
+
+        try {
+            const res = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/post/writer/${userId}`, {
+                withCredentials: true
+            });
+            setRecentPosts(res.data);
+        } catch (err) {
+            console.error('커뮤니티 게시글 불러오기 실패:', err);
+        }
+    };
+
+    fetchRecentPosts();
 }, [userId]);
 
     const today = new Date();
@@ -297,7 +317,13 @@ useEffect(() => {
                                                     <img src={entry.image} alt="entry" className={styles.entryImg} />
                                                 )}
                                                 <span className={styles.entryTitle}>{entry.title}</span>
-                                                <span className={styles.entryDate}>{entry.date}</span>
+                                                <span className={styles.entryDate}>
+                                                    {new Date(entry.date).toLocaleDateString('ko-KR', {
+                                                        year: 'numeric',
+                                                        month: '2-digit',
+                                                        day: '2-digit'
+                                                    })}
+                                                </span>
                                             </li>
                                         ))}
                                     </ul>
@@ -361,17 +387,20 @@ useEffect(() => {
                                 <section className={styles.journalSection}>
                                     <div className={styles.journalHeader}>
                                         <h2>최근 커뮤니티 게시글</h2>
-                                        {/*<div className={styles.logout} onClick={handleDiaryList}>더보기</div>*/}
                                     </div>
                                     <ul className={styles.journalList}>
-                                        {journalEntries.map((entry, idx) => (
-                                            <li key={idx} className={styles.journalItem}>
-                                                {entry.image &&
-                                                    <img src={entry.image} alt="entry" className={styles.entryImg}/>}
-                                                <span className={styles.entryTitle}>{entry.title}</span>
-                                                <span className={styles.entryDate}>{entry.date}</span>
-                                            </li>
-                                        ))}
+                                        {[...recentPosts]
+                                            .sort((a, b) => new Date(b.date) - new Date(a.date))
+                                            .slice(0, 3)
+                                            .map((entry, idx) => (
+                                                <li key={idx} className={styles.journalItem}>
+                                                    {entry.image && (
+                                                        <img src={entry.image} alt="entry" className={styles.entryImg} />
+                                                    )}
+                                                    <span className={styles.entryTitle}>{entry.title}</span>
+                                                    <span className={styles.entryDate}>{entry.date}</span>
+                                                </li>
+                                            ))}
                                     </ul>
                                 </section>
                             </>

--- a/src/pages/Profile/Profile.js
+++ b/src/pages/Profile/Profile.js
@@ -2,7 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {Doughnut} from 'react-chartjs-2';
 import {ArcElement, Chart as ChartJS, Legend, Tooltip} from 'chart.js';
 import dummyDiaries from '../../components/DummyData/dummyDiaries';
-import {useNavigate, useParams, useSearchParams} from 'react-router-dom';
+import {useNavigate, useParams} from 'react-router-dom';
 import Calendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 import '../../components/CustomCalendar/CalendarOverride.css';
@@ -16,16 +16,16 @@ import axios from "axios";
 
 // 팀 정보 맵 (예시, 실제 데이터는 프로젝트에서 적절히 import/정의 필요)
 const teamInfoMapCommunity = [
-    { teamId: 1, name: 'NC 다이노스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png` },
-    { teamId: 2, name: '삼성 라이온즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png` },
-    { teamId: 3, name: '두산 베어스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png` },
-    { teamId: 4, name: '한화 이글스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png` },
-    { teamId: 5, name: 'KIA 타이거즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png` },
-    { teamId: 6, name: 'KT 위즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png` },
-    { teamId: 7, name: '롯데 자이언츠', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png` },
-    { teamId: 8, name: 'LG 트윈스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png` },
-    { teamId: 9, name: 'SSG 랜더스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png` },
-    { teamId: 10, name: '키움 히어로즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png` }
+    {teamId: 1, name: 'NC 다이노스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_NC.png`},
+    {teamId: 2, name: '삼성 라이온즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SS.png`},
+    {teamId: 3, name: '두산 베어스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_OB.png`},
+    {teamId: 4, name: '한화 이글스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HH.png`},
+    {teamId: 5, name: 'KIA 타이거즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_HT.png`},
+    {teamId: 6, name: 'KT 위즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_KT.png`},
+    {teamId: 7, name: '롯데 자이언츠', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LT.png`},
+    {teamId: 8, name: 'LG 트윈스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_LG.png`},
+    {teamId: 9, name: 'SSG 랜더스', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_SK.png`},
+    {teamId: 10, name: '키움 히어로즈', logo: `${process.env.PUBLIC_URL}/Logo/TeamLogo/emblem_WO.png`}
 ];
 
 ChartJS.register(ArcElement, Tooltip, Legend);
@@ -57,7 +57,7 @@ const Profile = () => {
 
     // const [searchParams] = useSearchParams();
     // const userId = searchParams.get('userId');
-    const { userId } = useParams();
+    const {userId} = useParams();
 
     const [profile, setProfile] = useState(null);
     const [nickname, setNickname] = useState('');
@@ -99,69 +99,69 @@ const Profile = () => {
         }
     }, [isMine]);
 
-useEffect(() => {
-    const fetchProfile = async () => {
-        const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
-        try {
-            // Always fetch the logged-in user's profile to get their ID
-            const loggedInRes = await axios.get(`${baseUrl}/user/profile`, { withCredentials: true });
-            const loggedInData = loggedInRes.data;
-            setLoggedInUserId(loggedInData.id);
+    useEffect(() => {
+        const fetchProfile = async () => {
+            const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
+            try {
+                // Always fetch the logged-in user's profile to get their ID
+                const loggedInRes = await axios.get(`${baseUrl}/user/profile`, {withCredentials: true});
+                const loggedInData = loggedInRes.data;
+                setLoggedInUserId(loggedInData.id);
 
-            // Now fetch the target profile (could be mine or another user's)
-            let targetProfileUrl;
-            if (!userId) {
-                targetProfileUrl = `${baseUrl}/user/profile`;
-            } else {
-                targetProfileUrl = `${baseUrl}/user/profile/${userId}`;
+                // Now fetch the target profile (could be mine or another user's)
+                let targetProfileUrl;
+                if (!userId) {
+                    targetProfileUrl = `${baseUrl}/user/profile`;
+                } else {
+                    targetProfileUrl = `${baseUrl}/user/profile/${userId}`;
+                }
+                const res = await axios.get(targetProfileUrl, {withCredentials: true});
+                const data = res.data;
+                const favoriteTeams = data.favoriteTeams || [];
+                const primaryTeam = favoriteTeams.find(team => team.displayOrder === 1);
+
+                const teamLogoMap = {
+                    1: 'NC', 2: 'SS', 3: 'OB', 4: 'HH', 5: 'HT',
+                    6: 'KT', 7: 'LT', 8: 'LG', 9: 'SK', 10: 'WO'
+                };
+                const logoPrefix = teamLogoMap[primaryTeam?.teamId] || 'default';
+                const teamLogo = `TeamLogo/emblem_${logoPrefix}.png`;
+
+                setProfile({...data, teamLogo});
+                setNickname(data.nickname);
+
+                // Compare logged-in user ID with the profile being viewed
+                if (userId) {
+                    setIsMine(Number(loggedInData.id) === Number(userId));
+                } else {
+                    setIsMine(true);
+                }
+            } catch (err) {
+                console.error('프로필 불러오기 오류:', err);
+                setError('프로필을 불러오는 중 오류가 발생했습니다. 다시 시도해주세요.');
             }
-            const res = await axios.get(targetProfileUrl, { withCredentials: true });
-            const data = res.data;
-            const favoriteTeams = data.favoriteTeams || [];
-            const primaryTeam = favoriteTeams.find(team => team.displayOrder === 1);
+        };
 
-            const teamLogoMap = {
-                1: 'NC', 2: 'SS', 3: 'OB', 4: 'HH', 5: 'HT',
-                6: 'KT', 7: 'LT', 8: 'LG', 9: 'SK', 10: 'WO'
-            };
-            const logoPrefix = teamLogoMap[primaryTeam?.teamId] || 'default';
-            const teamLogo = `TeamLogo/emblem_${logoPrefix}.png`;
-
-            setProfile({ ...data, teamLogo });
-            setNickname(data.nickname);
-
-            // Compare logged-in user ID with the profile being viewed
-            if (userId) {
-                setIsMine(Number(loggedInData.id) === Number(userId));
-            } else {
-                setIsMine(true);
-            }
-        } catch (err) {
-            console.error('프로필 불러오기 오류:', err);
-            setError('프로필을 불러오는 중 오류가 발생했습니다. 다시 시도해주세요.');
-        }
-    };
-
-    fetchProfile();
-}, [userId]);
+        fetchProfile();
+    }, [userId]);
 
 // 최근 커뮤니티 게시글 fetch
-useEffect(() => {
-    const fetchRecentPosts = async () => {
-        if (!userId) return;
+    useEffect(() => {
+        const fetchRecentPosts = async () => {
+            if (!userId) return;
 
-        try {
-            const res = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/post/writer/${userId}`, {
-                withCredentials: true
-            });
-            setRecentPosts(res.data);
-        } catch (err) {
-            console.error('커뮤니티 게시글 불러오기 실패:', err);
-        }
-    };
+            try {
+                const res = await axios.get(`${process.env.REACT_APP_LOCAL_BACKEND_COMMUNITY_URI}/post/writer/${userId}`, {
+                    withCredentials: true
+                });
+                setRecentPosts(res.data);
+            } catch (err) {
+                console.error('커뮤니티 게시글 불러오기 실패:', err);
+            }
+        };
 
-    fetchRecentPosts();
-}, [userId]);
+        fetchRecentPosts();
+    }, [userId]);
 
     const today = new Date();
     const [value, setValue] = useState(today);
@@ -184,7 +184,7 @@ useEffect(() => {
                 try {
                     const res = await axios.get(
                         `${process.env.REACT_APP_LOCAL_BACKEND_URI}/user/${userId}/tags/summary`,
-                        { withCredentials: true }
+                        {withCredentials: true}
                     );
                     setTagSummary(res.data);
                 } catch (err) {
@@ -314,7 +314,7 @@ useEffect(() => {
                                         {recentDiaries.slice(0, 2).map((entry, idx) => (
                                             <li key={idx} className={styles.journalItem}>
                                                 {entry.image && (
-                                                    <img src={entry.image} alt="entry" className={styles.entryImg} />
+                                                    <img src={entry.image} alt="entry" className={styles.entryImg}/>
                                                 )}
                                                 <span className={styles.entryTitle}>{entry.title}</span>
                                                 <span className={styles.entryDate}>
@@ -350,8 +350,8 @@ useEffect(() => {
                                                         options={{
                                                             cutout: '70%',
                                                             plugins: {
-                                                                legend: { display: false },
-                                                                tooltip: { enabled: false }
+                                                                legend: {display: false},
+                                                                tooltip: {enabled: false}
                                                             }
                                                         }}
                                                     />
@@ -385,18 +385,20 @@ useEffect(() => {
                                         <h2>최근 커뮤니티 게시글</h2>
                                     </div>
                                     <ul className={styles.journalList}>
-                                        {[...recentPosts]
+                                        {Array.isArray(recentPosts) && recentPosts.length > 0 ? [...recentPosts]
                                             .sort((a, b) => new Date(b.date) - new Date(a.date))
                                             .slice(0, 3)
                                             .map((entry, idx) => (
                                                 <li key={idx} className={styles.journalItem}>
-                                                    {entry.image && (
-                                                        <img src={entry.image} alt="entry" className={styles.entryImg} />
+                                                    {entry?.image && (
+                                                        <img src={entry.image} alt="entry" className={styles.entryImg}/>
                                                     )}
-                                                    <span className={styles.entryTitle}>{entry.title}</span>
-                                                    <span className={styles.entryDate}>{entry.date}</span>
+                                                    <span className={styles.entryTitle}>{entry?.title || '제목 없음'}</span>
+                                                    <span className={styles.entryDate}>{entry?.date || ''}</span>
                                                 </li>
-                                            ))}
+                                            )) : (
+                                            <li className={styles.noPostsMessage}>게시글이 없습니다.</li>
+                                        )}
                                     </ul>
                                 </section>
                             </>
@@ -408,13 +410,13 @@ useEffect(() => {
                         title="로그아웃"
                         message="로그아웃하시겠어요?"
                         buttons={[
-                            { label: '취소', onClick: () => setShowLogoutModal(false) },
+                            {label: '취소', onClick: () => setShowLogoutModal(false)},
                             {
                                 label: '확인',
                                 onClick: async () => {
                                     const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
                                     try {
-                                        await axios.post(`${baseUrl}/auth/logout`, {}, { withCredentials: true });
+                                        await axios.post(`${baseUrl}/auth/logout`, {}, {withCredentials: true});
                                         navigate('/login');
                                     } catch (err) {
                                         navigate('/login');

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -150,7 +150,7 @@
 .journalItem {
   display: flex;
   align-items: center;
-  margin-bottom: 1rem;
+  margin: 1rem 0;
 }
 
 .entryImg {
@@ -165,6 +165,7 @@
   flex-grow: 1;
   font-size: 1rem;
   font-weight: 500;
+  margin-bottom: 5%;
 }
 
 .entryDate {

--- a/src/pages/Profile/Profile.module.css
+++ b/src/pages/Profile/Profile.module.css
@@ -174,6 +174,18 @@
   margin-left: 1rem;
 }
 
+.noPostsMessage {
+  text-align: center;
+  color: #999;
+  font-style: italic;
+  padding: 2rem 1rem;
+  margin: 1rem 0;
+  background-color: #f8f9fa;
+  border-radius: 8px;
+  border: 1px dashed #ddd;
+  list-style: none;
+}
+
 .accuracySection {
   width: 100%;
   min-height: 180px;


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. 직관일지 목록 자체 Pagination
![image](https://github.com/user-attachments/assets/cee2c31c-f3b2-49fe-b799-34a6e1953a71)

- 기존 spring pagination 대신 react pagination library를 적용
- 페이지당 8개의 직관일지 로드

### 2. 상대방 프로필 페이지 최근 게시글 노출
![image](https://github.com/user-attachments/assets/1ad82b9c-fc2e-42df-a8af-438b39f9c750)

- 최근 게시한 커뮤니티 포스트 3개 노출

---

## 🔗 관련 이슈
- closes #111 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 프로필 페이지에서 최근 커뮤니티 게시글을 동적으로 불러와 최대 3개까지 최신순으로 표시합니다.

- **버그 수정**
    - 프로필 페이지의 다이어리 날짜 표기 형식이 일관되게 변경되었습니다.
    - 프로필 이미지 업로드 실패 시 오류 안내 모달이 정상적으로 표시됩니다.

- **UI/스타일**
    - 다이어리 목록에서 팀 로고가 제목 옆에 표시되도록 레이아웃이 개선되었습니다.
    - 다이어리 및 커뮤니티 게시글 리스트의 여백과 정렬이 더욱 깔끔하게 조정되었습니다.

- **기타**
    - 다이어리 목록의 페이지네이션이 클라이언트 측에서 처리되도록 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->