### PR TITLE
Cs 423 fix/refresh token 활용 access token 재발급 로직 구현

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import axios from "axios";
+axios.defaults.withCredentials = true;
 import './sentry';
 import React from "react";
 import ReactDOM from "react-dom/client";

--- a/src/index.js
+++ b/src/index.js
@@ -4,16 +4,22 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 
 import AppRouter from "./routes/AppRouter";
-import { SearchProvider } from "./components/SearchContext"; 
+import { SearchProvider } from "./components/SearchContext";
 import { AuthProvider } from "./utils/AuthContext";
 import ReactQueryProvider from "./QueryClientProvider";
 
+import { HashRouter } from "react-router-dom";
+
 ReactDOM.createRoot(document.getElementById("root")).render(
     <ReactQueryProvider>
-        <AuthProvider>
-            <div className="fullscreen-container">
-                <AppRouter/>
-            </div>
-        </AuthProvider>
+        <HashRouter>
+            <AuthProvider>
+                <SearchProvider>
+                    <div className="fullscreen-container">
+                        <AppRouter />
+                    </div>
+                </SearchProvider>
+            </AuthProvider>
+        </HashRouter>
     </ReactQueryProvider>
 );

--- a/src/pages/Main/MainPage.js
+++ b/src/pages/Main/MainPage.js
@@ -36,36 +36,36 @@ export default function MainPage() {
     const eventSourceRef = useRef(null);
 
     function setupEventHandlers(es) {
-      // 서버가 전송하는 이벤트를 받을 때 처리
-      es.onmessage = (e) => {
-        const text = e.data;
-        if (text.trim().startsWith("{")) {
-          try {
-            const notification = JSON.parse(text);
-            console.log("새 알림 도착:", notification);
-            // TODO: 받은 알림을 상태나 Context에 저장하여 화면에 반영
-          } catch (err) {
-            console.error("JSON 파싱 중 오류:", err);
-          }
-        } else {
-          console.log("SSE 비-JSON 메시지:", text);
-        }
-      };
-
-      es.onerror = (err) => {
-        console.error("SSE 연결 오류:", err);
-          if (es.readyState === EventSource.CLOSED) {
-                  console.log("SSE 연결이 닫혔습니다. 5초 후 재연결 시도...");
-                  setTimeout(() => {
-                        if (eventSourceRef.current === es) {
-                              const newEs = new EventSource(sseUrl, { withCredentials: true });
-                              eventSourceRef.current = newEs;
-                              // 이벤트 핸들러 재설정
-                                  setupEventHandlers(newEs);
-                            }
-                      }, 5000);
+        // 서버가 전송하는 이벤트를 받을 때 처리
+        es.onmessage = (e) => {
+            const text = e.data;
+            if (text.trim().startsWith("{")) {
+                try {
+                    const notification = JSON.parse(text);
+                    console.log("새 알림 도착:", notification);
+                    // TODO: 받은 알림을 상태나 Context에 저장하여 화면에 반영
+                } catch (err) {
+                    console.error("JSON 파싱 중 오류:", err);
                 }
-      };
+            } else {
+                console.log("SSE 비-JSON 메시지:", text);
+            }
+        };
+
+        es.onerror = (err) => {
+            console.error("SSE 연결 오류:", err);
+            if (es.readyState === EventSource.CLOSED) {
+                console.log("SSE 연결이 닫혔습니다. 5초 후 재연결 시도...");
+                setTimeout(() => {
+                    if (eventSourceRef.current === es) {
+                        const newEs = new EventSource(sseUrl, { withCredentials: true });
+                        eventSourceRef.current = newEs;
+                        // 이벤트 핸들러 재설정
+                        setupEventHandlers(newEs);
+                    }
+                }, 5000);
+            }
+        };
     }
 
     useEffect(() => {
@@ -102,49 +102,49 @@ export default function MainPage() {
     }, []);
 
     useEffect(() => {
-      const fetchMyApprovalPartyDetail = async () => {
-        if (!loginUserId) return;
-        try {
-          const twpBase = process.env.REACT_APP_LOCAL_BACKEND_TWP_URI;
-          const listRes = await axios.get(
-            `${twpBase}/party`,
-            {
-              params: { matchId: 1, deletedAt: null },
-              withCredentials: true
+        const fetchMyApprovalPartyDetail = async () => {
+            if (!loginUserId) return;
+            try {
+                const twpBase = process.env.REACT_APP_LOCAL_BACKEND_TWP_URI;
+                const listRes = await axios.get(
+                    `${twpBase}/party`,
+                    {
+                        params: { matchId: 1, deletedAt: null },
+                        withCredentials: true
+                    }
+                );
+                const myParties = listRes.data.filter(
+                    (p) => p.writerId === loginUserId
+                );
+                if (myParties.length > 0) {
+                    const partyId = myParties[0].partyId;
+                    const detailRes = await axios.get(
+                        `${twpBase}/party/${partyId}`,
+                        { withCredentials: true }
+                    );
+                    setMyApprovalPartyDetail(detailRes.data);
+                }
+            } catch (err) {
+                console.error("내가 승인한 직관팟 정보 조회 실패:", err);
             }
-          );
-          const myParties = listRes.data.filter(
-            (p) => p.writerId === loginUserId
-          );
-          if (myParties.length > 0) {
-            const partyId = myParties[0].partyId;
-            const detailRes = await axios.get(
-              `${twpBase}/party/${partyId}`,
-              { withCredentials: true }
-            );
-            setMyApprovalPartyDetail(detailRes.data);
-          }
-        } catch (err) {
-          console.error("내가 승인한 직관팟 정보 조회 실패:", err);
-        }
-      };
-      fetchMyApprovalPartyDetail();
+        };
+        fetchMyApprovalPartyDetail();
     }, [loginUserId]);
 
     // SSE 구독: 로그인 후 "/home"에 도착할 때 바로 실행
     useEffect(() => {
-      // 브라우저 기본 EventSource는 쿠키에 들어있는 JWT를 자동으로 포함
-      const es = new EventSource(sseUrl, { withCredentials: true });
-      eventSourceRef.current = es;
+        // 브라우저 기본 EventSource는 쿠키에 들어있는 JWT를 자동으로 포함
+        const es = new EventSource(sseUrl, { withCredentials: true });
+        eventSourceRef.current = es;
 
-      setupEventHandlers(es);
+        setupEventHandlers(es);
 
-      // 컴포넌트 언마운트 시에는 EventSource 닫기
-      return () => {
-        if (eventSourceRef.current) {
-          eventSourceRef.current.close();
-        }
-      };
+        // 컴포넌트 언마운트 시에는 EventSource 닫기
+        return () => {
+            if (eventSourceRef.current) {
+                eventSourceRef.current.close();
+            }
+        };
     }, []);
 
     const handleOpenModal = () => {
@@ -178,58 +178,58 @@ export default function MainPage() {
 
     // Fetch today's matches
     useEffect(() => {
-      const fetchTodayMatches = async () => {
-        try {
-          const token = document.cookie
-            .split("; ")
-            .find((row) => row.startsWith("Access="))
-            ?.split("=")[1];
-          const res = await axios.get(
-            `${process.env.REACT_APP_AI_API_BASE}/matches`,
-            {
-              headers: { Authorization: `Bearer ${token}` },
-              withCredentials: true,
-              params: { date: today },
+        const fetchTodayMatches = async () => {
+            try {
+                const token = document.cookie
+                    .split("; ")
+                    .find((row) => row.startsWith("Access="))
+                    ?.split("=")[1];
+                const res = await axios.get(
+                    `${process.env.REACT_APP_AI_API_BASE}/matches`,
+                    {
+                        headers: { Authorization: `Bearer ${token}` },
+                        withCredentials: true,
+                        params: { date: today },
+                    }
+                );
+                setAllMatches(res.data);
+            } catch (err) {
+                console.error("오늘 경기 조회 실패:", err);
             }
-          );
-          setAllMatches(res.data);
-        } catch (err) {
-          console.error("오늘 경기 조회 실패:", err);
-        }
-      };
-      fetchTodayMatches();
+        };
+        fetchTodayMatches();
     }, [today]);
 
     const todaySchedule = React.useMemo(() => {
-      if (!selectedTeam || allMatches.length === 0) return null;
-      return (
-        allMatches.find(
-          (m) =>
-            m.home_team_name === selectedTeam ||
-            m.away_team_name === selectedTeam
-        ) || null
-      );
+        if (!selectedTeam || allMatches.length === 0) return null;
+        return (
+            allMatches.find(
+                (m) =>
+                    m.home_team_name === selectedTeam ||
+                    m.away_team_name === selectedTeam
+            ) || null
+        );
     }, [allMatches, selectedTeam]);
 
     const scheduleForSection = todaySchedule
-      ? {
-          home: todaySchedule.home_team_name,
-          away: todaySchedule.away_team_name,
-          status:
-            todaySchedule.status_code === "RESULT"
-              ? "종료"
-              : todaySchedule.status_code === "STARTED"
-              ? "경기중"
-              : "경기전",
-          score: [
-            todaySchedule.away_team_score ?? 0,
-            todaySchedule.home_team_score ?? 0,
-          ],
+        ? {
+            home: todaySchedule.home_team_name,
+            away: todaySchedule.away_team_name,
+            status:
+                todaySchedule.status_code === "RESULT"
+                    ? "종료"
+                    : todaySchedule.status_code === "STARTED"
+                        ? "경기중"
+                        : "경기전",
+            score: [
+                todaySchedule.away_team_score ?? 0,
+                todaySchedule.home_team_score ?? 0,
+            ],
         }
-      : null;
+        : null;
 
     const onEnterChat = (chatRoomId) => {
-      navigate(`/chat/party/${chatRoomId}`);
+        navigate(`/chat/party/${chatRoomId}`);
     };
 
     return (
@@ -243,9 +243,9 @@ export default function MainPage() {
             <div>
                 <h2 className={styles.sectionTitle}>오늘의 일정</h2>
                 {scheduleForSection ? (
-                  <ScheduleSection schedule={scheduleForSection} />
+                    <ScheduleSection schedule={scheduleForSection} />
                 ) : (
-                  <p className={styles.noContentText}>해당 팀의 경기가 없습니다.</p>
+                    <p className={styles.noContentText}>해당 팀의 경기가 없습니다.</p>
                 )}
 
                 <h2 className={styles.sectionTitleWithMargin}>인기 포스트</h2>
@@ -258,61 +258,61 @@ export default function MainPage() {
             </div>
             <h2 className={styles.sectionTitleWithMargin}>나의 직관팟</h2>
             {myApprovalPartyDetail && (
-              <div
-                className={styles.partyCard}
-                onClick={() => onEnterChat(myApprovalPartyDetail.partyId)}
-                style={{ cursor: "pointer" }}
-              >
-                <img
-                  src={myApprovalPartyDetail.partyThumbnailUrls?.[0] || `${process.env.PUBLIC_URL}/Logo/jikgwanprofile.png`}
-                  alt="직관팟 썸네일"
-                  className={styles.playerImg}
-                />
-                <div className={styles.partyContent}>
-                  <div className={styles.tags}>
-                    <span className={styles.tag}>{myApprovalPartyDetail.partyJoinMethod}</span>
-                    {myApprovalPartyDetail.partyAges?.map((tag, index) => (
-                      <span
-                        key={index}
-                        className={`${styles.tag} ${index === 2 ? styles.tagHighlight : ''}`}
-                      >
+                <div
+                    className={styles.partyCard}
+                    onClick={() => onEnterChat(myApprovalPartyDetail.partyId)}
+                    style={{ cursor: "pointer" }}
+                >
+                    <img
+                        src={myApprovalPartyDetail.partyThumbnailUrls?.[0] || `${process.env.PUBLIC_URL}/Logo/jikgwanprofile.png`}
+                        alt="직관팟 썸네일"
+                        className={styles.playerImg}
+                    />
+                    <div className={styles.partyContent}>
+                        <div className={styles.tags}>
+                            <span className={styles.tag}>{myApprovalPartyDetail.partyJoinMethod}</span>
+                            {myApprovalPartyDetail.partyAges?.map((tag, index) => (
+                                <span
+                                    key={index}
+                                    className={`${styles.tag} ${index === 2 ? styles.tagHighlight : ''}`}
+                                >
                         {tag}
                       </span>
-                    ))}
-                    <span className={`${styles.tag} ${styles.tagHighlight}`}>
+                            ))}
+                            <span className={`${styles.tag} ${styles.tagHighlight}`}>
                       {myApprovalPartyDetail.availableGender}
                     </span>
-                  </div>
-                  <div className={styles.partyTitle}>{myApprovalPartyDetail.title}</div>
-                  <div className={styles.partyMeta}>
-                    <span>{myApprovalPartyDetail.authorName || '작성자'}</span>
-                    <span>{myApprovalPartyDetail.authorAge || '나이'}</span>
-                    <span>
+                        </div>
+                        <div className={styles.partyTitle}>{myApprovalPartyDetail.title}</div>
+                        <div className={styles.partyMeta}>
+                            <span>{myApprovalPartyDetail.authorName || '작성자'}</span>
+                            <span>{myApprovalPartyDetail.authorAge || '나이'}</span>
+                            <span>
                       {myApprovalPartyDetail.authorGender === 'MALE'
-                        ? '남성'
-                        : myApprovalPartyDetail.authorGender === 'FEMALE'
-                          ? '여성'
-                          : '기타'}
+                          ? '남성'
+                          : myApprovalPartyDetail.authorGender === 'FEMALE'
+                              ? '여성'
+                              : '기타'}
                     </span>
-                    <span>· {myApprovalPartyDetail.matchDate}</span>
-                  </div>
+                            <span>· {myApprovalPartyDetail.matchDate}</span>
+                        </div>
 
-                  <div className={styles.partyStatus}>
-                    <div className={styles.avatars}>
-                      {myApprovalPartyDetail.userThumbnailUrls?.slice(0, 1).map((url, i) => (
-                        <img
-                          key={i}
-                          src={url || `${process.env.PUBLIC_URL}/Logo/profile.png`}
-                          alt="프로필"
-                        />
-                      ))}
+                        <div className={styles.partyStatus}>
+                            <div className={styles.avatars}>
+                                {myApprovalPartyDetail.userThumbnailUrls?.slice(0, 1).map((url, i) => (
+                                    <img
+                                        key={i}
+                                        src={url || `${process.env.PUBLIC_URL}/Logo/profile.png`}
+                                        alt="프로필"
+                                    />
+                                ))}
+                            </div>
+                            <div className={styles.slot}>
+                                {myApprovalPartyDetail.currentParticipantsCount}/{myApprovalPartyDetail.maximumParticipantsCount}
+                            </div>
+                        </div>
                     </div>
-                    <div className={styles.slot}>
-                      {myApprovalPartyDetail.currentParticipantsCount}/{myApprovalPartyDetail.maximumParticipantsCount}
-                    </div>
-                  </div>
                 </div>
-              </div>
             )}
             {/* TODO: 이후 ISSUE에서 TWP SERVICE merge 이후 적용 예정 */}
             {/*{parties.length > 0 ? (*/}

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -27,7 +27,7 @@ import Community from '../pages/Community/Community';
 
 function AppRouter() {
     return (
-        <Router>
+        // <Router>
             <Routes>
                 {/* 로그인 & 회원가입 */}
                 <Route path="/" element={<Splash/>}/>
@@ -107,7 +107,7 @@ function AppRouter() {
                     <Route index element={<DiaryDetail/>}/>
                 </Route>
             </Routes>
-        </Router>
+        // </Router>
     );
 }
 

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -28,85 +28,85 @@ import Community from '../pages/Community/Community';
 function AppRouter() {
     return (
         // <Router>
-            <Routes>
-                {/* 로그인 & 회원가입 */}
-                <Route path="/" element={<Splash/>}/>
-                <Route path="/login" element={<Login/>}/>
-                <Route path="/choice-team" element={<TeamChoice/>}/>
-                <Route path="/setprofile" element={<SetProfile/>}/>
-                <Route path="/login-complete" element={<LoginComplete/>}/>
-                {/* 메인 화면 */}
-                <Route path="/home" element={<MobileView/>}>
-                    <Route index element={<MainPage/>}/>
-                </Route>
-                {/* 커뮤니티 */}
-                <Route path="/community/post/:team" element={<MobileView/>}>
-                    <Route index element={<Community/>}/>
-                </Route>
-                <Route path="/community/post/:team/:postId" element={<MobileView/>}>
-                    <Route index element={<PostDetail />} />
-                </Route>
-                {/* 일정 & 직관팟 */}
-                {/* 일정 메인 */}
-                <Route path="/schedule" element={<MobileView/>}>
-                    <Route index element={<Schedule/>}/>
-                </Route>
-                <Route path="/newpost" element={<MobileView />}>
-                    <Route index element={<NewPost />} />
-                </Route>
-                <Route path="/search" element={<MobileView />}>
-                    <Route index element={<SearchResultPage />} />
-                </Route>
-                {/* 경기 정보 */}
-                <Route path="/schedule/:gameId" element={<MobileView/>}>
-                    <Route index element={<MatchInfo/>}/>
-                </Route>
-                {/* 직관팟 목록 */}
-                <Route path="/party/:gameId" element={<MobileView/>}>
-                    <Route index element={<Party/>}/>
-                </Route>
-                {/* 직관팟 상세 */}
-                <Route path="/party/matchid/:partyId" element={<MobileView/>}>
-                    <Route index element={<PartyDetail/>}/>
-                </Route>
-                {/* 직관팟 만들기 */}
-                <Route path="/party/newparty" element={<MobileView/>}>
-                    <Route index element={<PartyMake/>}/>
-                </Route>
-                {/* 직관팟 수정하기 */}
-                <Route path="/party/edit/:partyId" element={<MobileView/>}>
-                    <Route index element={<PartyMake mode="edit" />} />
-                </Route>
-                {/* 직관팟 신청하기 */}
-                <Route path="/party/applyparty/:partyId" element={<MobileView/>}>
-                    <Route index element={<PartyApply/>}/>
-                </Route>
-                {/* 직관팟 입장 시 채팅방 */}
-                <Route path="/chat/party/:chatRoomId" element={<MobileView/>}>
-                    <Route index element={<Chatting/>}/>
-                </Route>
-                {/* 직관팟 후기 페이지 */}
-                <Route path="/review/party/:partyId" element={<MobileView/>}>
-                    <Route index element={<ReviewParty/>}/>
-                </Route>
-                {/* 프로필 & 직관일지 */}
-                {/* 프로필 메인 & 타 사용자 프로필 */}
-                <Route path="/profile/:userId" element={<MobileView/>}>
-                    <Route index element={<Profile/>}/>
-                </Route>
-                {/* 직관일지 목록 */}
-                <Route path="/diary/list/:id" element={<MobileView/>}>
-                    <Route index element={<DiaryList/>}/>
-                </Route>
-                {/* 직관일지 작성 */}
-                <Route path="/diary/newdiary" element={<MobileView/>}>
-                    <Route index element={<NewDiary/>}/>
-                </Route>
-                {/* 직관일지 상세 */}
-                <Route path="/diary/:tag/:id" element={<MobileView/>}>
-                    <Route index element={<DiaryDetail/>}/>
-                </Route>
-            </Routes>
+        <Routes>
+            {/* 로그인 & 회원가입 */}
+            <Route path="/" element={<Splash/>}/>
+            <Route path="/login" element={<Login/>}/>
+            <Route path="/choice-team" element={<TeamChoice/>}/>
+            <Route path="/setprofile" element={<SetProfile/>}/>
+            <Route path="/login-complete" element={<LoginComplete/>}/>
+            {/* 메인 화면 */}
+            <Route path="/home" element={<MobileView/>}>
+                <Route index element={<MainPage/>}/>
+            </Route>
+            {/* 커뮤니티 */}
+            <Route path="/community/post/:team" element={<MobileView/>}>
+                <Route index element={<Community/>}/>
+            </Route>
+            <Route path="/community/post/:team/:postId" element={<MobileView/>}>
+                <Route index element={<PostDetail />} />
+            </Route>
+            {/* 일정 & 직관팟 */}
+            {/* 일정 메인 */}
+            <Route path="/schedule" element={<MobileView/>}>
+                <Route index element={<Schedule/>}/>
+            </Route>
+            <Route path="/newpost" element={<MobileView />}>
+                <Route index element={<NewPost />} />
+            </Route>
+            <Route path="/search" element={<MobileView />}>
+                <Route index element={<SearchResultPage />} />
+            </Route>
+            {/* 경기 정보 */}
+            <Route path="/schedule/:gameId" element={<MobileView/>}>
+                <Route index element={<MatchInfo/>}/>
+            </Route>
+            {/* 직관팟 목록 */}
+            <Route path="/party/:gameId" element={<MobileView/>}>
+                <Route index element={<Party/>}/>
+            </Route>
+            {/* 직관팟 상세 */}
+            <Route path="/party/matchid/:partyId" element={<MobileView/>}>
+                <Route index element={<PartyDetail/>}/>
+            </Route>
+            {/* 직관팟 만들기 */}
+            <Route path="/party/newparty" element={<MobileView/>}>
+                <Route index element={<PartyMake/>}/>
+            </Route>
+            {/* 직관팟 수정하기 */}
+            <Route path="/party/edit/:partyId" element={<MobileView/>}>
+                <Route index element={<PartyMake mode="edit" />} />
+            </Route>
+            {/* 직관팟 신청하기 */}
+            <Route path="/party/applyparty/:partyId" element={<MobileView/>}>
+                <Route index element={<PartyApply/>}/>
+            </Route>
+            {/* 직관팟 입장 시 채팅방 */}
+            <Route path="/chat/party/:chatRoomId" element={<MobileView/>}>
+                <Route index element={<Chatting/>}/>
+            </Route>
+            {/* 직관팟 후기 페이지 */}
+            <Route path="/review/party/:partyId" element={<MobileView/>}>
+                <Route index element={<ReviewParty/>}/>
+            </Route>
+            {/* 프로필 & 직관일지 */}
+            {/* 프로필 메인 & 타 사용자 프로필 */}
+            <Route path="/profile/:userId" element={<MobileView/>}>
+                <Route index element={<Profile/>}/>
+            </Route>
+            {/* 직관일지 목록 */}
+            <Route path="/diary/list/:id" element={<MobileView/>}>
+                <Route index element={<DiaryList/>}/>
+            </Route>
+            {/* 직관일지 작성 */}
+            <Route path="/diary/newdiary" element={<MobileView/>}>
+                <Route index element={<NewDiary/>}/>
+            </Route>
+            {/* 직관일지 상세 */}
+            <Route path="/diary/:tag/:id" element={<MobileView/>}>
+                <Route index element={<DiaryDetail/>}/>
+            </Route>
+        </Routes>
         // </Router>
     );
 }

--- a/src/utils/AuthContext.js
+++ b/src/utils/AuthContext.js
@@ -1,31 +1,53 @@
-// src/context/AuthContext.js
 import { createContext, useContext, useEffect, useState } from 'react';
 import axios from 'axios';
+import { useNavigate } from 'react-router-dom';
 
 const AuthContext = createContext(null);
 
 export const AuthProvider = ({ children }) => {
     const [user, setUser] = useState(null);
     const baseUrl = process.env.REACT_APP_LOCAL_BACKEND_URI;
+    const navigate = useNavigate();
 
-    // ✅ 여기에 fetchMyInfo 함수 넣기
+    useEffect(() => {
+        const interceptor = axios.interceptors.response.use(
+            res => res,
+            async error => {
+                const originalRequest = error.config;
+
+                if (error.response?.status === 401 && !originalRequest._retry) {
+                    originalRequest._retry = true;
+                    try {
+                        await axios.post(`${baseUrl}/auth/refresh`, {}, { withCredentials: true });
+                        return axios(originalRequest);
+                    } catch {
+                        navigate("/login");
+                        return Promise.reject(error);
+                    }
+                }
+                return Promise.reject(error);
+            }
+        );
+
+        return () => axios.interceptors.response.eject(interceptor);
+    }, [baseUrl, navigate]);
+
     const fetchMyInfo = async () => {
         const res = await axios.get(`${baseUrl}/user/profile`, { withCredentials: true });
-        return res.data; // { id, nickname, ... }
+        return res.data;
     };
 
     useEffect(() => {
         const loadUser = async () => {
             try {
-                const userData = await fetchMyInfo(); // 호출 위치
+                const userData = await fetchMyInfo();
                 setUser(userData);
             } catch (err) {
                 console.error("사용자 정보 불러오기 실패", err);
             }
         };
-
         loadUser();
-    }, []);
+    }, [baseUrl]);
 
     return (
         <AuthContext.Provider value={{ user }}>

--- a/src/utils/AuthContext.js
+++ b/src/utils/AuthContext.js
@@ -18,9 +18,12 @@ export const AuthProvider = ({ children }) => {
                 if (error.response?.status === 401 && !originalRequest._retry) {
                     originalRequest._retry = true;
                     try {
-                        await axios.post(`${baseUrl}/auth/refresh`, {}, { withCredentials: true });
+                        console.log("🔄 AccessToken 만료됨, 재발급 시도 중...");
+                        const res = await axios.post(`${baseUrl}/user/auth/reissue`, {}, { withCredentials: true });
+                        console.log("✅ AccessToken 재발급 성공:", res);
                         return axios(originalRequest);
-                    } catch {
+                    } catch (e) {
+                        console.warn("❌ AccessToken 재발급 실패:", e);
                         navigate("/login");
                         return Promise.reject(error);
                     }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(주석, 개행 등등..)
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 테스트 코드 추가

---

## ✏️ 작업 내용
### 1. Access Token 만료 확인 후 Refresh Token 기반 자동 재발급 로직 적용

- 단, local 환경에서 테스트 진행 시 User 서비스의 TokenService.java 중 `.domain(domain)` 부분을 주석 처리해줘야 함.
`useEffect(() => {
        const interceptor = axios.interceptors.response.use(
            res => res,
            async error => {
                const originalRequest = error.config;

                if (error.response?.status === 401 && !originalRequest._retry) {
                    originalRequest._retry = true;
                    try {
                        console.log("🔄 AccessToken 만료됨, 재발급 시도 중...");
                        const res = await axios.post(`${baseUrl}/user/auth/reissue`, {}, { withCredentials: true });
                        console.log("✅ AccessToken 재발급 성공:", res);
                        return axios(originalRequest);
                    } catch (e) {
                        console.warn("❌ AccessToken 재발급 실패:", e);
                        navigate("/login");
                        return Promise.reject(error);
                    }
                }
                return Promise.reject(error);
            }
        );

        return () => axios.interceptors.response.eject(interceptor);
    }, [baseUrl, navigate]);`
    코드를 통한 axios API 통신을 탈취하여 먼저 401 Response를 통해 Access Token의 만료 여부를 판단하고, 이후 재발급 요청을 먼저 수행

---

## 🔗 관련 이슈
- closes #114 

---

## 💡 추가 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 해시 기반의 URL 라우팅이 도입되어 앱 내에서 페이지 전환이 가능합니다.
    - 검색 컨텍스트가 추가되어 전역적으로 검색 상태를 관리할 수 있습니다.

- **버그 수정**
    - 인증 토큰이 만료될 경우 자동으로 토큰을 갱신하고, 실패 시 로그인 페이지로 이동하도록 개선되었습니다.

- **스타일**
    - 일부 파일에서 코드의 들여쓰기 및 포맷이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->